### PR TITLE
Apply spec-template system to repo

### DIFF
--- a/.claude/commands/intake.md
+++ b/.claude/commands/intake.md
@@ -1,6 +1,6 @@
 # Intake
 
-Process the ideas in `specs/INTAKE.md` and file them into the appropriate TODO spec files.
+Process ideas from `specs/INTAKE.md` — and from open GitHub Issues — and file them into the appropriate TODO spec files.
 
 ## Step 1 — Ensure INTAKE.md exists
 
@@ -13,17 +13,19 @@ If it **does not exist**:
 ```markdown
 # Ideas intake
 
-Too lazy to search for the right spec to update?  Throw your idea here and let the LLMs put it in the right place(s) later!
+Not sure where your idea belongs? Drop it here and let the LLMs file it in the right place later!
 
 ## AGENTS Instructions
 
-When asked to, take any items listed below and organize put them into the appropriate TODO spec file.  Ideas may be vague, rambling, or half-baked.  If necessary, ask clarifying questions to determine what the user's intent was.  If a single item refers to multiple components or is a particularly large/complex idea, it can be broken into multiple separate TODOs in the relevant `*.todo.spec`.
+When asked to, take any items listed below and put them into the appropriate `.todo.md` file. Ideas may be vague, rambling, or half-baked. If necessary, ask clarifying questions to determine the user's intent. If a single item refers to multiple components or is a particularly large/complex idea, break it into multiple TODOs across the relevant `.todo.md` files.
 
-If a requested item already exists in the TODO spec, that implies a higher priority.  Tell the user and ask if they want to add any details or move it higher in the TODO spec.
+Use your best judgement to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
 
 When you have emptied the submissions section below, leave behind a single bullet:
 
 - *Add your ideas here*.
+
+Items waiting for more information stay in this file with a date annotation: `*(waiting for response, asked YYYY-MM-DD)*`. Re-surface stale items after **7 days** with no reply — change this number to adjust the threshold. If the user asks to defer an item, annotate it as `*(snoozed until YYYY-MM-DD)*` and skip it until that date.
 
 ## Submissions
 
@@ -32,61 +34,166 @@ When you have emptied the submissions section below, leave behind a single bulle
 
 Then tell the user the file has been created and stop — there is nothing to process yet.
 
-## Step 2 — Read the Submissions
+## Step 2 — Check waiting and snoozed items
 
-Read `specs/INTAKE.md`. Extract every bullet under `## Submissions`, ignoring the placeholder `*Add your ideas here*` bullet. If the Submissions section is empty (only the placeholder), tell the user there is nothing to process and stop.
+Read `specs/INTAKE.md` and scan for items with date annotations before doing anything else.
 
-## Step 3 — Survey existing TODO spec files
+**For each item annotated `*(waiting for response, asked YYYY-MM-DD)*`:**
+1. If the item has a `[#N](url)` prefix, run `gh issue view N --json comments` and check whether any comments were posted after the asked date.
+2. New comments found → strip the annotation and re-add the item to the processing queue for this run.
+3. No new comments and older than **7 days** (default; see AGENTS Instructions to adjust) → add to the stale list. Surface in the Step 8 report: "Still waiting on #N (asked YYYY-MM-DD)."
+4. No new comments and within 7 days → skip silently.
+
+**For each item annotated `*(snoozed until YYYY-MM-DD)*`:**
+- Snooze date is in the future → skip entirely.
+- Snooze date has passed → strip the annotation and re-add to the processing queue.
+
+**During the run**, if the user says to defer a stale item ("we'll get to it in May", "ignore this for now"):
+- Update its annotation to `*(snoozed until YYYY-MM-DD)*` based on what they said.
+- Move on without posting to GH.
+
+## Step 3 — Pull from GitHub Issues
+
+**Config:** Read `specs/.meta.json` if it exists and check `auto_create_issues`:
+- `true` → enable issue auto-creation for this run.
+- `false` → disable; skip silently.
+- Key absent (or `.meta.json` missing entirely) → ask the user: *"Should I create a GitHub issue for each manual submission that has no issue link? (Set `auto_create_issues` in `specs/.meta.json` to avoid this prompt.)"*
+  - User confirms → treat as `true` for this run.
+  - User declines → treat as `false` for this run.
+  - No user present (headless) → treat as `false`; note in the Step 8 report that `auto_create_issues` was unset and no issues were created.
+
+1. Run `gh auth status` using the Bash tool.
+   - If `gh` is not installed or the user is not authenticated: skip the rest of this step, make a note for the report, and continue to Step 4.
+2. Run: `gh issue list --state open --json number,title,url,labels --limit 100`
+3. Filter out any issues that already carry one of these labels: `intake:filed`, `intake:rejected`, `intake:ignore`.
+4. For each remaining issue, append a bullet to the `## Submissions` section of `specs/INTAKE.md`:
+   ```
+   - [#N](url) Issue title
+   ```
+5. If no unprocessed issues are found, note it and continue.
+
+## Step 4 — Read the Submissions
+
+Read `specs/INTAKE.md`. Extract every bullet under `## Submissions` that is not:
+- The placeholder `*Add your ideas here*`
+- A `*(waiting for response...)*` or `*(snoozed until...)*` item that was not re-queued in Step 2
+
+If nothing remains to process, tell the user and stop (include the Step 8 report if there were stale items to surface).
+
+## Step 5 — Survey existing TODO spec files
 
 Use Grep to find all `*.todo.md` files under `specs/`. Read their headings so you understand what components/areas each file covers. Do not read every line — just enough to map file → component/area.
 
-## Step 4 — Process each item
+## Step 6 — Process each item
 
-For each submission item:
+For each item, determine which of three paths applies:
 
-1. **Determine the target spec file.** Match the item to the most relevant `*.todo.md` based on the component or area it describes. If the item spans multiple components, split it into one entry per relevant spec file.
+---
 
-2. **Check for duplicates.** Grep the target spec file for similar wording. If a near-identical item exists:
-   - Tell the user: "This item already exists in `<file>`: `<existing text>`."
-   - Ask if they want to add details or move it higher in priority before continuing.
+### Path 1 — Routed (clear intent, known target)
 
-3. **Clarify vague items.** If the item's intent is ambiguous — you cannot confidently determine what component it targets, what behavior is wanted, or which spec file it belongs in — ask the user a specific clarifying question before filing it. Do not guess on ambiguous intent.
+You can confidently identify the target `.todo.md` and the item is not a duplicate.
 
-4. **Determine placement.** Append new items to the end of the relevant spec file's unchecked TODO list, or insert at the top if the item seems high-priority based on context. Use your judgment.
+1. **Determine the target.** Match the item to the most relevant `.todo.md`. For work that needs to happen in a dependency, file it in `specs/deps/{repo}.todo.md` (create it if needed). If the item spans multiple components, split it into one entry per relevant file.
 
-5. **Format the TODO entry.** Write it as a `- [ ]` checkbox with a concise, actionable description. Expand vague language into clear implementation intent. If the original submission contains multiple sub-bullets, preserve them as indented sub-bullets under the main checkbox.
+2. **Format the entry.** Write it as a plain `- ` bullet. For GH-sourced items, preserve the issue link as a prefix:
+   ```
+   - [#42](url) Description of what needs to happen
+   ```
+   For manual items, write a concise, actionable description. If the submission has sub-bullets, preserve them as indented sub-bullets.
 
-6. **Create the spec file if missing.** If no suitable `*.todo.md` exists for the item, create one at an appropriate path under `specs/` (mirroring the component hierarchy if one exists). Use this minimal template:
+3. **Auto-create a GH issue** if the item has no `[#N](url)` prefix, `auto_create_issues` is `true` for this run, **and** Step 3 confirmed that the GitHub CLI is installed and authenticated:
+   - If Step 3 reported that `gh` is missing or unauthenticated, **do not** attempt `gh issue create`; treat auto-creation as disabled for this run and record it in the Step 8 report.
+   - Otherwise, run: `gh issue create --title "<concise title>" --body "<item description>"`
+   - Extract the issue number from the returned URL and update the entry to prepend `[#N](url)`.
+   - If creation still fails for any other reason (e.g. permission or network error), continue without a link and note the failure in the Step 8 report.
 
-```markdown
-# <Component/Area Name> — TODOs
+4. **Create the spec file if missing.** Use this minimal template:
+   ```markdown
+   # <Component/Area/Dep Name> — TODOs
 
-- [ ] <first item>
-```
+   - <first item>
+   ```
+   For dep TODOs, see `specs/deps/README.md` for the recommended template.
 
-## Step 5 — Clear INTAKE.md
+5. **Apply a GitHub label** if the item has a `[#N](url)` prefix:
+   - **Filed:** `gh issue edit N --add-label "intake:filed"`
+   - **User rejects the idea:** `gh issue edit N --add-label "intake:rejected"` — skip filing
+   - **User says leave it alone:** `gh issue edit N --add-label "intake:ignore"` — skip filing
 
-After all items are filed, update `specs/INTAKE.md` so the Submissions section contains only the placeholder:
+6. **Clear from INTAKE.md** (handled in Step 7).
 
-```markdown
-## Submissions
+---
 
-- *Add your ideas here*.
-```
+### Path 2 — Duplicate+boost (near-identical item already exists)
 
-## Step 6 — Report
+You find an existing TODO item that covers the same ground.
+
+1. **Find the existing item.** Grep the relevant spec file for similar wording. Show the user what you found: "This item already exists in `<file>`: `<existing text>`."
+
+2. **Boost the existing item:**
+   - Append any new details from the duplicate as a sub-bullet on the existing item.
+   - If the duplicate has a GH issue, link it as an additional sub-bullet: `  - Also requested: [#N](url)`
+   - If this item has now been duplicated multiple times, ask the user whether it should be promoted to a higher section (e.g. Backlog → Later → Sooner). Move it only with user approval.
+
+3. **Apply `intake:filed`** to the duplicate GH issue (if applicable).
+
+4. **Clear from INTAKE.md** (handled in Step 7).
+
+---
+
+### Path 3 — Needs more info (ambiguous routing, missing requirements, low confidence)
+
+You cannot confidently route the item without additional context.
+
+1. **Do not apply any GH label yet.**
+
+2. **Post a comment on the GH issue**, clearly marked as from Claude — not the user:
+   ```
+   🤖 Claude: automated message from /intake — not from the developer.
+
+   To route this issue I need a bit more information:
+   [1–3 specific questions]
+
+   My best routing guess: [target file or component] (confidence: low/medium — reason)
+
+   Reply here to proceed.
+   ```
+   If a human was present in the chat during this run and discussion happened: summarize that conversation in the comment before the questions, then post. This keeps GH as the canonical record even for supervised runs.
+
+   For items with no GH issue (manual submissions): ask the user directly in chat instead.
+
+3. **Annotate the item** in INTAKE.md by appending `*(waiting for response, asked YYYY-MM-DD)*` (use today's date).
+
+4. **Leave it in INTAKE.md** — do not clear it in Step 7.
+
+---
+
+## Step 7 — Selective clearing of INTAKE.md
+
+After all items are processed, update `specs/INTAKE.md`:
+- **Remove** items that were routed (Path 1) or duplicate+boosted (Path 2).
+- **Leave** items annotated `*(waiting for response...)*` or `*(snoozed until...)*` exactly as they are.
+- Ensure the Submissions section always ends with the placeholder bullet if it would otherwise be empty:
+  ```markdown
+  - *Add your ideas here*.
+  ```
+
+## Step 8 — Report
 
 Give the user a brief summary:
 - Which items were filed and where.
-- Any items that were split across multiple spec files.
-- Any duplicates found.
-- Any spec files that were newly created.
+- Any items split across multiple spec files.
+- Any duplicates found and how they were boosted.
+- Any spec files newly created.
+- **Waiting:** any items newly marked as waiting for more info (with the GH link).
+- **Stale:** any items that have been waiting longer than 7 days with no reply.
+- **GitHub:** which issues were labeled and how; any issues auto-created for manual submissions (when `auto_create_issues` is enabled). If `gh` was unavailable, note it here.
 
 ## Preferred tools
 
 - **Read** — read INTAKE.md and existing spec files
 - **Grep** — find existing TODO spec files and check for duplicate entries
-- **Edit** — update spec files and clear INTAKE.md
+- **Edit** — update spec files and INTAKE.md annotations
 - **Write** — create new spec files or INTAKE.md if missing
-
-Do not use Bash for any file operations — use Read, Write, Grep, and Edit instead.
+- **Bash** — `gh` CLI calls only (auth check, issue list, issue view, issue edit, issue comment); use the file tools above for all file operations

--- a/.claude/commands/knock-out-todos.md
+++ b/.claude/commands/knock-out-todos.md
@@ -6,43 +6,88 @@ Number to tackle: $ARGUMENTS (default 5 if blank)
 
 ## How to find TODOs
 
-Use the Grep tool to search for `^\- \[ \]` across all `specs/**/*.todo.md` files. Read the results and assess relative difficulty. Skip items that are TBD placeholders or that clearly require decisions from the user (e.g. "open questions", "TBD", or items requiring new full components with no spec yet).
+Use the Grep tool to search for `^- ` across all `specs/**/*.todo.md` files. Read the results and assess relative difficulty. Skip items that are TBD placeholders or that clearly require decisions from the user (e.g. "open questions", "TBD", or items requiring new full components with no spec yet).
 
 ## How to choose which items to tackle
 
 Prefer items that:
 - Have clear, self-contained requirements
-- Affect existing components (additions/tweaks over full new components)
-- Can be done with file edits alone — CSS changes, adding props, small behavior additions
-- Do not require user input or clarification to proceed
+- Affect existing code (modifications or additions to existing modules)
+- Can be done with file edits alone — focused, localized changes
+- Are independent and do not require user input or clarification to proceed
 
 Avoid items that:
 - Say "TBD" or leave requirements unresolved
-- Require a brand-new component with no existing skeleton
-- Involve routing, backend, or third-party integrations
+- Require building entirely new modules or major architectural changes
+- Require external dependencies or third-party integrations not yet in place
 - Would require asking the user a question before starting
 
 ## Workflow
 
-1. Read all unchecked TODOs using Grep. Scan quickly — you do not need to read every spec file in full.
-2. Read the relevant source files (components, CSS, stories) for the items you've chosen using the Read tool.
-3. Implement the changes using the Edit and Write tools.
-4. Mark each completed item done by editing its `.todo.md` file directly — change `- [ ]` to `- [x]` using the Edit tool. Do not use terminal commands to do this.
-5. Update `CHANGELOG.md` under `## WIP` with a concise summary of what was done (max ~5 bullets, brief).
-6. Run `npm run typecheck` once at the end to confirm everything compiles.
+1. Read all open TODO items using Grep. Scan quickly — you do not need to read every spec file in full.
+
+2. For each chosen item, check its context before doing anything else:
+
+   **If the item is in `specs/deps/`** — "implementing" this item means opening a downstream GitHub issue, not writing product code. Follow the [Dep TODO flow](#dep-todo-flow) below instead of the standard steps.
+
+   **If the item has dep sub-bullets** (indented lines in the form `  - [{repo}#{N}](url)`):
+   - Check the status of each: `gh issue view N --repo {owner}/{repo} --json state,title`
+   - Any sub-bullet issue still open → item is blocked. Note it and skip — report the blocker to the user.
+   - All sub-bullet issues closed → item is unblocked. Proceed with implementation or validation.
+
+   **If the item has a `[#N](url)` GitHub issue prefix** — fetch details:
+   - Run `gh issue view N --json title,body,comments` using the Bash tool.
+   - Read the body and any comments for additional context, acceptance criteria, or unresolved questions.
+   - Meaningful detail or discussion → incorporate it into the implementation plan.
+   - Sparse body with no comments → check with the user before proceeding.
+
+3. Read the relevant source files for the items you've chosen using the Read tool.
+4. Implement the changes using the Edit and Write tools.
+5. For each completed item: (a) remove it from its `.todo.md` file using the Edit tool; (b) add its description to the appropriate section of `spec.md` to reflect current state. Drop any dep sub-bullets when promoting — they are implementation history, not current state. If the item has a `[#N](url)` GitHub issue prefix, note the issue number — collect all of them for the wrap-up step.
+6. Update `CHANGELOG.md` under `## WIP` with a concise summary of what was done (max ~5 bullets, brief). If any completed items were GH-linked, output a ready-to-paste block at the end of your summary:
+
+   ```
+   To close linked issues on merge, add to your PR description:
+   closes #42
+   closes #17
+   ```
+
+7. Run the appropriate build or validation command for the project to confirm changes compile and pass checks.
+
+---
+
+## Dep TODO flow
+
+When a chosen item lives in `specs/deps/{repo}.todo.md`, follow this flow instead of the standard implementation steps:
+
+1. Draft a GitHub issue from the TODO description. Write the title and body so the target repo has enough context to act on it independently — don't assume they know this repo's internals.
+2. Open the issue: `gh issue create --repo {owner}/{repo} --title "..." --body "..."`
+3. Add a sub-bullet to the local TODO item:
+   ```
+   - [#local](url) Description
+     - [{repo}#{N}]({url}) Downstream issue opened
+   ```
+4. Cross-link both issues with comments for traceability:
+   - On the local issue: `gh issue comment {local-N} --body "🤖 Claude: Downstream issue opened in {repo}: [{repo}#{N}]({url})"`
+   - On the downstream issue: `gh issue comment {dep-N} --repo {owner}/{repo} --body "🤖 Claude: Opened on behalf of [{this-repo}#{local-N}]({url})"`
+5. Leave the TODO item in place — it stays open until the downstream issue is closed. Sub-bullet reconciliation (step 2 above) will unblock it on the next run.
 
 ## Preferred tools and actions
 
-- **Grep** — find TODO items and search source files
-- **Read** — read component source, CSS, and stories before editing
-- **Edit** and **Write** — make all changes including marking TODOs done and updating the CHANGELOG
-- **Bash** — only for `npm run typecheck` at the end; avoid for anything else
-
-Do not use Bash to check off boxes, list files, or search for patterns — use Grep and Read instead.
+- **Grep** — find TODO items and search source files for relevant code
+- **Read** — read source files for the items you've chosen before implementing
+- **Edit** and **Write** — make all code changes, mark TODOs as complete, move items to main spec, and update the CHANGELOG
+- **Bash** — `gh` calls only (`gh issue view` to read context and check dep status, `gh issue create` to open downstream dep issues, `gh issue comment` to cross-link); use the file tools above for all file operations
 
 ## Style rules
 
-- Follow existing BEM naming (`nw-` prefix), motion tokens, and component conventions already established in the codebase
-- Add or update Storybook stories for anything user-visible
-- No new runtime dependencies
+- Follow existing code conventions and patterns already established in the codebase
+- Avoid adding new dependencies unless explicitly required by the spec
 - Keep changes minimal and focused — do not refactor surrounding code that was not part of the TODO
+
+## Reminders
+
+* `spec.md` = current state | `spec.todo.md` = future plans | INTAKE = entry point
+* Completed work belongs in `spec.md` — remove items from todo files when done, never leave completed items behind
+* Items flow: INTAKE → `spec.todo.md` → `{feature}.todo.md` (if big) → `spec.md` (when done)
+* GH-linked items (`[#N]`): include `closes #N` in your PR description — GitHub closes the issue on merge

--- a/.claude/commands/refine.md
+++ b/.claude/commands/refine.md
@@ -1,0 +1,174 @@
+# Refine
+
+Add technical detail, effort estimates, and priority adjustments to the highest-priority open TODO items — the middle step between `/intake` and `/knock-out-todos`.
+
+The user may specify how many items to refine — default is **3** if not stated.
+Number to refine: `$ARGUMENTS` (default 3 if blank).
+
+---
+
+## Step 1 — Find and prioritize TODO items
+
+Use Grep to search for `^- ` across all `specs/**/*.todo.md` files.
+
+**Skip items that are:**
+- Already refined: have a `*(effort: ...)` annotation **and** at least one indented technical sub-bullet
+- Snoozed: annotated `*(snoozed until YYYY-MM-DD)*` where the date is still in the future
+- Reminders or section headings (lines not starting with `- `)
+
+**Re-check waiting items first.** For each item annotated `*(waiting for response, asked YYYY-MM-DD)*`:
+1. If the item has a `[#N](url)` prefix, run `gh issue view N --json comments` and check for comments posted after the asked date.
+2. New comments found → strip the annotation and add the item to the candidate pool (treat as high priority — the user has responded).
+3. No new comments and older than **7 days** → add to the stale list for Step 6.
+4. No new comments and within 7 days → skip silently.
+
+**Prioritize candidates:**
+1. Items in "Sooner" sections before "Later" before "Backlog" within each file
+2. Higher position in the file (earlier = higher priority)
+3. Items with a `[#N](url)` GH issue prefix (proxy for stakeholder interest)
+
+Select the top N items (default 3; user-specified number overrides).
+
+---
+
+## Step 2 — Load context for each item
+
+For each selected item:
+
+1. **GH issue details:** If the item has a `[#N](url)` prefix, run `gh issue view N --json title,body,comments`. Read the body and all comments — these may contain requirements, constraints, or previous discussion.
+2. **Spec file context:** Read the containing `.todo.md` file to understand the area and neighboring items.
+3. **Current state:** Read the relevant component spec (`specs/spec.md`, `specs/scaffold.md`, `specs/worker.md`, etc.) to understand what already exists.
+4. **Source scan:** If relevant source files exist and are small, do a light scan to understand the implementation surface.
+
+---
+
+## Step 3 — Assess and refine each item
+
+For each item, work through these questions:
+
+**Clarity check:**
+- Is the **what** (deliverable, behavior, interface) clear enough to implement without guessing?
+- Is the **why** (purpose, user value, problem being solved) clear?
+- Are there **implementation decisions** that need to be made before work can start?
+- Are there known **dependencies** or **risks**?
+
+**Estimate effort** using these labels:
+- **XS** — trivial change, < 1 hour
+- **S** — small and well-understood, < half a day
+- **M** — moderate complexity, 1–2 days
+- **L** — substantial, spans multiple components, 3–5 days
+- **XL** — large; must be broken down further before implementation
+- **Unknown** — not enough information to estimate yet
+
+---
+
+### If supervised (user present in chat)
+
+- Ask questions directly in chat. Work iteratively — do not write anything to files until key ambiguities are resolved.
+- Confirm the effort estimate with the user.
+- If the user adjusts scope, priority, or approach during discussion, note it before writing.
+- Get explicit sign-off from the user before proceeding to Step 4.
+
+---
+
+### If headless (no user in chat)
+
+- Make a best-effort assessment using available context (GH issue body/comments, spec files, source).
+- For questions about **product decisions or intent** (the "why" or "what") that cannot be answered from context, post a clarifying comment on the GH issue:
+
+  ```
+  🤖 Claude: automated message from /refine — not from the developer.
+
+  I'm preparing this item for implementation and have some questions:
+  [1–3 specific, answerable questions]
+
+  My current understanding: [brief summary of what will be built and how]
+  Estimated effort: [XS/S/M/L/XL/Unknown — one-line reasoning]
+
+  Reply here and I'll incorporate your answers on the next run.
+  ```
+
+- Annotate the item as `*(waiting for response, asked YYYY-MM-DD)*` if key product decisions remain unanswered.
+- Still add an effort estimate and whatever technical detail can be inferred from context — do not leave the item completely unrefined just because some questions remain.
+
+---
+
+## Step 4 — Write updates to spec and TODO files
+
+**In the `.todo.md` file:**
+
+Add an inline effort estimate and technical sub-bullets to each refined item:
+
+```
+- [#N](url) Description of the item *(effort: M)*
+  - Implementation: [brief technical approach — how it will be built]
+  - Depends on: [prerequisites or blockers, if any]
+```
+
+If no GH issue prefix exists:
+```
+- Description of the item *(effort: S)*
+  - Implementation: [brief technical approach]
+```
+
+Additional rules:
+- If priority was adjusted during Step 3, move the item to the appropriate section (Sooner / Later / Backlog).
+- If a GH comment was posted in headless mode, append `*(waiting for response, asked YYYY-MM-DD)*` to the item.
+- Do not add speculative or unconfirmed details — only what was agreed or clearly inferable.
+
+**In related spec files** (only when the purpose or approach genuinely improved):
+- Add or update the feature description in `spec.md` or the relevant component spec.
+- Do not add unconfirmed design decisions.
+
+---
+
+## Step 5 — Commit and open a PR
+
+### Supervised
+
+After the user gives sign-off in Step 3:
+1. Commit all changes.
+2. Push the branch.
+3. Ask the user: *"Ready to open a PR with these changes?"*
+4. On confirmation, run:
+   ```
+   gh pr create --title "refine: ..." --body "..."
+   ```
+   PR body should include:
+   - List of items refined with their effort estimates
+   - Any outstanding questions (items still waiting for GH replies)
+   - `closes #N` for any GH issues that are now fully defined
+
+### Headless
+
+1. Commit all changes.
+2. Push the branch.
+3. Run `gh pr create` automatically. Preface the PR body with:
+
+   > 🤖 Claude: This PR was generated by `/refine`. Review the proposed spec changes and reply on the linked GH issues if adjustments are needed — I'll incorporate answers on the next run.
+
+   Then include:
+   - List of items refined with effort estimates and brief implementation summary
+   - Outstanding questions: items where GH comments were posted (with issue links)
+   - `closes #N` lines for any GH issues that are fully defined and no longer need questions answered
+
+**PR title format:** `refine: add detail and estimates for [item names or area]`
+
+---
+
+## Step 6 — Report
+
+Give the user (or include in the PR description) a brief summary:
+- **Refined:** each item, its new effort estimate, and the key technical decision or clarification added
+- **Waiting:** items where a GH comment was posted asking for more info (with issue link)
+- **Stale:** items that have been waiting longer than 7 days with no reply
+- **PR:** link to the opened PR
+
+---
+
+## Preferred tools
+
+- **Grep** — find TODO items across spec files
+- **Read** — read spec files, GH issue details, source files for context
+- **Edit** — update TODO items and spec files
+- **Bash** — `gh` CLI calls only (issue view, issue comment, pr create); use the file tools above for all file operations

--- a/.claude/commands/respec.md
+++ b/.claude/commands/respec.md
@@ -1,0 +1,126 @@
+# /respec
+
+Apply or refresh the [spec-template](https://github.com/NoahWright87/spec-template) system in this repository.
+
+This command handles three situations:
+1) A fresh repo with no specs yet
+2) An existing `specs/` folder that predates this template
+3) A repo already running this template that needs updating.
+
+It detects which case applies and walks you through each step.
+
+**Non-Claude users:** This file is plain markdown. Read it and apply it in your tool of choice — the instructions are the same regardless of IDE.
+
+For the reasoning behind how this command is written, see [PHILOSOPHY.md](https://github.com/NoahWright87/spec-template/blob/main/PHILOSOPHY.md).
+
+---
+
+## Step 1 — Assess the repo
+
+Use Glob to check for `specs/` and Read to check for `specs/.meta.json`.
+
+| What exists | Path to take |
+|-------------|--------------|
+| No `specs/` directory | [Fresh install](#fresh-install) |
+| `specs/` exists, no `.meta.json` | [Adaptation](#adaptation) |
+| `specs/` exists with `.meta.json` | [Update](#update) |
+
+---
+
+## Fresh install
+
+### What to copy
+
+Fetch the latest versions of the managed files (listed in [Managed files](#managed-files)) from the source repo and write them into this repo at the same relative paths.
+
+The source repo URL is whatever URL you fetched this command from. It will be recorded in `specs/.meta.json`.
+
+### What to ask the user first
+
+Before writing the optional files below, describe what each one would add and ask the user whether to include it:
+
+- **Root `AGENTS.md`** — offers agent instructions for the whole repo, with a section on using specs. If one already exists, offer to append a spec section to it rather than replacing it.
+- **`CHANGELOG.md`** — a blank changelog template. If one already exists, leave it in place and skip this offer.
+
+Write only what the user approves.
+
+### After writing files
+
+Write `specs/.meta.json` with the source repo URL, the current commit hash (fetch it from the source repo), and today's date:
+
+```json
+{
+  "source": "https://github.com/YOUR_USERNAME/spec-template",
+  "commit": "COMMIT_HASH",
+  "date": "YYYY-MM-DD"
+}
+```
+
+Users may add optional config keys to this file at any time (e.g. `"auto_create_issues": true`). Never remove or overwrite keys not listed above.
+
+Then give the user a brief summary: which files were written, which optional files were included, and what to do next (run `/intake` or add specs).
+
+---
+
+## Adaptation
+
+The repo already has a `specs/` folder, but it was not set up with this template. The goal is to meld the template's structure with what's already there — adding what's missing and proposing merges where files overlap. The user approves each change before anything is written.
+
+### What to do
+
+1. Read all existing files under `specs/` using Glob and Read.
+2. For each managed file (see [Managed files](#managed-files)):
+   - **Absent:** Show the user what the template version looks like and ask whether to add it.
+   - **Present, compatible:** Show the user both versions side by side and propose a merge. The user decides what to keep.
+   - **Present, serving the same purpose:** Propose replacing the existing file with the template version, showing both so the user can compare.
+3. Write only what the user approves, one file at a time.
+4. Once the user is satisfied, write `specs/.meta.json` (same format as above).
+5. Report a summary: what changed, what was left in place, and any notes on differences found.
+
+---
+
+## Update
+
+The repo is already running this template. Fetch upstream changes and apply them to the managed files.
+
+### What to do
+
+1. Read `specs/.meta.json` for the source URL and last-known commit.
+2. Fetch the current versions of all managed files from the source URL.
+3. For each managed file, compare the fetched version to the local copy:
+   - **Unchanged:** Skip silently.
+   - **Changed:** Show the user a summary of what changed and ask whether to apply it.
+4. Apply approved updates. Leave everything else in place.
+5. **Check TODO format migration.** Compare the fetched `specs/spec.todo.md` template against all local `*.todo.md` files. If the template uses a different bullet format than what the repo's TODO files currently use (e.g. the template now uses plain `- ` bullets but local files still use `- [ ]` checkboxes), tell the user what changed and offer to migrate. If the user approves, update the local TODO files to the current format, preserving all content. Apply only what the user approves.
+6. Update `specs/.meta.json` with the new commit hash and today's date. Preserve all other keys exactly — do not remove or modify user-set fields such as `auto_create_issues`.
+7. Report what was updated, what was skipped, and whether a TODO format migration was applied.
+
+---
+
+## Managed files
+
+These are the files this command installs and keeps current. Everything else in the repo stays untouched.
+
+| File | Purpose |
+|------|---------|
+| `specs/README.md` | Explains the spec system to humans |
+| `specs/AGENTS.md` | Explains the spec system to agents |
+| `specs/spec.md` | Template for writing a new spec |
+| `specs/spec.todo.md` | Template for writing a new TODO spec |
+| `specs/INTAKE.md` | Intake bucket for ideas and requests |
+| `.claude/commands/intake.md` | `/intake` command |
+| `.claude/commands/knock-out-todos.md` | `/knock-out-todos` command |
+| `.claude/commands/spec-backfill.md` | `/spec-backfill` command |
+| `.claude/commands/respec.md` | This command |
+| `.claude/commands/refine.md` | `/refine` command |
+| `.github/workflows/spec-check.yml` | PR check: warns when source changes lack spec updates |
+| `specs/deps/README.md` | Explains the deps/ pattern; templates for dep specs and dep TODOs |
+
+---
+
+## Preferred tools
+
+- **Glob** — discover what exists under `specs/` and `.claude/commands/`
+- **Read** — examine existing files before proposing changes
+- **WebFetch** — fetch managed files from the source repo using raw GitHub URLs
+- **Write** and **Edit** — apply changes after the user confirms

--- a/.claude/commands/spec-backfill.md
+++ b/.claude/commands/spec-backfill.md
@@ -1,0 +1,147 @@
+# /spec-backfill
+
+Bootstrap or improve specs that mirror the codebase. Works for greenfield repos with no specs, brownfield repos with partial coverage, and already-spec'd repos that need a completeness check.
+
+**`$ARGUMENTS`** — optional plain-language scope or depth hint. Examples:
+- *(no arguments)* — scan for gaps and incomplete specs, report, ask what to do next
+- `go deep in the auth module` — read source + tests for that area and fill specs
+- `just map the top level` — create top-level placeholders only, skip submodules
+- `check completeness` — report placeholder counts without creating anything
+
+Re-running this command at any time is the completeness check. It is idempotent.
+
+For the reasoning behind this command's design, see [PHILOSOPHY.md](https://github.com/NoahWright87/spec-template/blob/main/PHILOSOPHY.md).
+
+---
+
+## Phase 1 — Assess the repo
+
+Use Glob to discover:
+
+**Source roots** — look for: `src/`, `app/`, `lib/`, `packages/*/src/`, `services/*/src/`. Note all that exist.
+
+**Test roots** — look for: `test/`, `tests/`, `__tests__/`, `spec/` (non-spec-template), `cypress/`, `playwright/`, `e2e/`, `integration/`. Note all that exist.
+
+**Existing specs coverage** — map what already exists under `specs/`. For each existing spec file, count occurrences of `> **TODO:**` to measure incompleteness.
+
+If `$ARGUMENTS` names a specific module or area, note it — that area gets priority in all later phases.
+
+---
+
+## Phase 2 — STOP POINT: report and confirm
+
+Present a concise summary before writing anything:
+
+1. **Gaps** — source modules with no corresponding spec file. List: source path → proposed spec path.
+2. **Incomplete specs** — existing spec files that still contain `> **TODO:**` placeholders. List: file path → placeholder count.
+3. **Proposed mapping** — how `src/**` would mirror into `specs/**`.
+
+Then ask the user:
+
+- "Should I create placeholder specs for the [N] unmapped modules?"
+- "Should I also read test files to fill in the Acceptance sections?" *(ask only if test roots were found)*
+- If `$ARGUMENTS` requested a deep read: "I'll read source + tests for [area] — confirm?"
+
+Write nothing until the user approves. If the user says "just show me the report," stop here.
+
+---
+
+## Phase 3 — Create placeholder specs
+
+For each unmapped source module the user approved, create a spec file using the existing `spec.md` template. Fill any section that can be reasonably inferred from the module's name, directory, or obvious purpose. Mark every section that cannot be determined with `> **TODO:**`.
+
+**File placement:**
+- Small or simple module (few files, single clear purpose) → `specs/{module}.spec.md`
+- Larger or multi-concern module → `specs/{module}/spec.md`, with optional `specs/{module}/{submodule}.spec.md` for distinct sub-concerns
+
+**Placeholder template** (used for every created spec):
+
+```markdown
+# {Module Name} Spec
+
+## Purpose
+> **TODO:** Why does this exist? Who or what depends on it?
+
+## Related
+> **TODO:** Link to related specs once they exist.
+
+## Contract
+
+### Inputs
+> **TODO:** What does this accept? (requests, parameters, events, config, user actions)
+
+### Outputs
+> **TODO:** What does this produce or affect? (responses, UI, side effects, persisted data)
+
+### Guarantees / Constraints
+> **TODO:** Invariants, ordering, auth expectations, performance expectations.
+
+## Behavior
+> **TODO:** Describe the happy path, alternate paths, error states, and notable edge cases.
+
+## User Experience (UX)
+> **TODO:** How do consumers (users or developers) interact with this?
+
+## Acceptance
+> **TODO:** Fill from tests. What behaviors are asserted and where?
+```
+
+Fill the Purpose section with whatever the module name and location suggest, even if brief. A partial answer is better than a placeholder that will sit forever.
+
+---
+
+## Phase 4 — Fill Acceptance from tests (if approved)
+
+For each spec with a `> **TODO:**` Acceptance section:
+
+1. Find relevant test files by path similarity (`src/foo/**` ↔ tests mentioning `foo`), import references, and naming conventions (`foo.test.ts`, `FooService.spec.ts`, etc.).
+2. Prioritize test types: e2e / integration / contract first; unit tests sparingly — skip assertions about internal implementation details.
+3. Translate `describe` / `it` blocks into behavioral AC bullets in the Acceptance section. Focus on observable outcomes.
+4. After the ACs, note the source test file paths so the link is traceable.
+5. Where tests are too thin or unclear to produce honest ACs: leave the `> **TODO:**` in place and add a note: `> **TODO:** Test coverage is sparse here — add integration tests before relying on this section.`
+
+---
+
+## Phase 5 — Fill from source (deep mode)
+
+For the area named in `$ARGUMENTS`:
+
+1. Read source files in that area. Understand what the module accepts, produces, and guarantees.
+2. Fill the Contract (Inputs, Outputs, Guarantees) and Behavior sections with what the code reveals.
+3. Where the code's behavior is clear but the *intent* is unclear, note it: `> **TODO:** Behavior observed, but intent unclear — verify with module owner.`
+4. Deep mode is scoped to the named area only. A full-repo deep read is too slow and token-heavy to be useful.
+
+---
+
+## Phase 6 — Report
+
+After each run, give the user:
+
+- Files created (paths)
+- Files updated (paths + what changed)
+- Total `> **TODO:**` placeholders remaining across all specs in `specs/`
+- Suggested next steps:
+  - Re-run `/spec-backfill` at any time to check remaining gaps
+  - Run `/spec-backfill go deep in [area]` to fill a specific module
+  - Run `/intake` to file any new ideas that surfaced during this review
+
+---
+
+## Placeholder convention
+
+Unfilled spec sections use `> **TODO:** description`. This format:
+- Renders visibly in GitHub (blockquote, bold label)
+- Is greppable: `> \*\*TODO\*\*`
+- Signals clearly that a section needs attention
+
+Filling a placeholder means replacing the `> **TODO:**` line with real content. Partial fills are fine — leave `> **TODO:**` for the parts that remain unknown.
+
+---
+
+## Preferred tools
+
+- **Glob** — discover source roots, test roots, and existing spec coverage
+- **Read** — read source files, test files, and existing specs before proposing changes
+- **Grep** — find `> **TODO:**` placeholders across existing specs; find test files by path/name pattern
+- **Write** — create new spec files after the user approves
+- **Edit** — update existing spec files (fill placeholders, add new sections)

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -1,0 +1,183 @@
+name: Spec Coverage Check
+
+# Warns (without blocking) when source files change in a PR without a
+# corresponding update somewhere in specs/. The warning comment is
+# formatted for an LLM to read and act on (e.g. run /spec-backfill).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Edit SOURCE_ROOTS to match your repo's layout.
+# Space-separated list of source root directories to check against specs/.
+env:
+  SOURCE_ROOTS: "src app lib"
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  spec-coverage:
+    name: Check spec coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for git diff against base branch
+
+      - name: Detect uncovered source changes
+        id: check
+        run: |
+          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+
+          spec_changes=()
+          src_changes=()
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            if [[ "$file" == specs/* ]]; then
+              spec_changes+=("$file")
+            else
+              for root in $SOURCE_ROOTS; do
+                if [[ "$file" == "$root/"* ]]; then
+                  src_changes+=("$file")
+                  break
+                fi
+              done
+            fi
+          done <<< "$changed"
+
+          # No source changes in this PR — nothing to check
+          if [[ ${#src_changes[@]} -eq 0 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          # For each changed source file, look for a spec file that shares
+          # a path prefix. Matching is intentionally loose: specs/auth/ covers
+          # src/auth/login.js, src/auth/register.js, etc.
+          uncovered=()
+          for src_file in "${src_changes[@]}"; do
+            # Strip source root to get relative path
+            # e.g. src/auth/login.js -> auth/login.js
+            relative=""
+            for root in $SOURCE_ROOTS; do
+              if [[ "$src_file" == "$root/"* ]]; then
+                relative="${src_file#"$root/"}"
+                break
+              fi
+            done
+
+            dir=$(dirname "$relative")  # auth for auth/login.js, . for login.js
+            covered=false
+
+            if [[ "$dir" == "." ]]; then
+              # Root-level source file: any spec change is considered coverage
+              [[ ${#spec_changes[@]} -gt 0 ]] && covered=true
+            else
+              # Walk up the ancestor chain looking for a matching spec change
+              # e.g. auth/services -> auth -> (root)
+              check_dir="$dir"
+              while [[ -n "$check_dir" && "$check_dir" != "." ]]; do
+                for spec_file in "${spec_changes[@]}"; do
+                  spec_rel="${spec_file#specs/}"
+                  # Match if the spec file lives under this directory component
+                  if [[ "$spec_rel" == "$check_dir/"* || "$spec_rel" == "$check_dir."* ]]; then
+                    covered=true
+                    break
+                  fi
+                done
+                [[ "$covered" == "true" ]] && break
+                parent=$(dirname "$check_dir")
+                [[ "$parent" == "$check_dir" ]] && break
+                check_dir="$parent"
+              done
+            fi
+
+            [[ "$covered" == "false" ]] && uncovered+=("$src_file")
+          done
+
+          echo "has_uncovered=$([ ${#uncovered[@]} -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+          # Write uncovered list (newline-delimited heredoc — safe for any path)
+          {
+            echo "uncovered_list<<UNCOVERED_EOF"
+            printf '%s\n' "${uncovered[@]}"
+            echo "UNCOVERED_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          HAS_UNCOVERED: ${{ steps.check.outputs.has_uncovered }}
+          UNCOVERED_LIST: ${{ steps.check.outputs.uncovered_list }}
+        with:
+          script: |
+            const marker = '<!-- spec-coverage-check -->';
+            const hasUncovered = process.env.HAS_UNCOVERED === 'true';
+            const raw = process.env.UNCOVERED_LIST || '';
+            const uncovered = raw.trim() ? raw.trim().split('\n') : [];
+            // P avoids a bare '|' at the start of a YAML line, which trips GitHub's parser
+            const P = '|';
+
+            let body;
+            if (!hasUncovered) {
+              body = `${marker}\n✅ All changed source files have corresponding spec updates in this PR.`;
+            } else {
+              const rows = uncovered.map(f => {
+                // Build suggested spec paths from most-specific to least-specific
+                // e.g. src/auth/services/login.js -> specs/auth/services/, specs/auth/
+                const parts = f.replace(/^[^/]+\//, '').split('/');
+                parts.pop(); // remove filename
+                const suggestions = [];
+                let path = '';
+                for (const part of parts) {
+                  path = path ? `${path}/${part}` : part;
+                  suggestions.unshift(`\`specs/${path}/\``);
+                }
+                return `${P} \`${f}\` ${P} ${suggestions.join(', ') || '`specs/`'} ${P}`;
+              }).join('\n');
+
+              body = `${marker}
+## ⚠️ Spec coverage warning
+
+These source files changed in this PR without a corresponding update in \`specs/\`:
+
+${P} Source file ${P} Suggested spec locations ${P}
+${P}-------------|--------------------------|
+${rows}
+
+**To fix:** update the relevant specs and push, or run \`/spec-backfill\` to generate them.
+
+*This warning is informational — it does not block merging.*`;
+            }
+
+            // Find the existing bot comment (if any) and update or create
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else if (hasUncovered) {
+              // Only create a new comment when there are warnings;
+              // don't clutter PRs that never had uncovered files
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ storybook-static
 .vscode
 .idea
 *.tgz
+.tmp/
 
 # Local AI assistant settings
 .claude/**/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
+- **Spec-template adoption:** Applied managed spec-template files and metadata (`specs/.meta.json`), added command/workflow scaffolding (`/respec`, `/refine`, `/spec-backfill`, spec coverage check), and aligned intake/todo command docs with upstream behavior.
+- **Repo hygiene:** Added `.tmp/` to `.gitignore` and removed the temporary `.tmp` workspace folder used during template fetch.
+
 - **PR review follow-ups:** fixed Storybook import order and duplicate preview file, added SSR-safe portfolio navigation guard, tightened Card typing, improved clipboard/keyboard accessibility in Text + Colors stories, made header hover tooltips decorative-only for screen readers, added MIT LICENSE, and stopped tracking local `.claude/settings.local.json`.
 - **Form components (overhaul):** Input/Select/Checkbox/RadioGroup gain `required` validation with auto-error on blur, error waggle animation, `randomDisabledCursor`, and spring-bounce animations on Checkbox/RadioGroup. Input adds `multiline`/`rows` (textarea), email format validation. RadioGroup required-validation story uses a Submit button. Error spans now always rendered (reserved space via `min-height: 1.25em`) to prevent layout shift; `aria-live="polite"` on all error spans.
 - **Molecules enriched:** Pill — `icon` + `onDismiss` + whimsical dismiss animation + neutral default color + `href`/`target` link variant (renders as `<a>` with hover outline). Heading gains `color`, `align`, `truncate`, `gradient`, `underline`, `eyebrow`, `iconStart`/`iconEnd`, `animateIn` (IntersectionObserver fade+slide on viewport entry), `anchorLink` (¶ hover button copies anchor URL to clipboard).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file documents planned and completed changes for the repository.
 ## WIP
 
 - **Spec-template adoption:** Applied managed spec-template files and metadata (`specs/.meta.json`), added command/workflow scaffolding (`/respec`, `/refine`, `/spec-backfill`, spec coverage check), and aligned intake/todo command docs with upstream behavior.
+- **Spec localization pass:** Rewrote root specs (`specs/spec.md`, `specs/spec.todo.md`) and legacy directory meta specs (`specs/.spec.md`, `specs/.spec.todo.md`) so they describe this design-system repo and use local placeholders instead of spec-template-repo content.
 - **Repo hygiene:** Added `.tmp/` to `.gitignore` and removed the temporary `.tmp` workspace folder used during template fetch.
 
 - **PR review follow-ups:** fixed Storybook import order and duplicate preview file, added SSR-safe portfolio navigation guard, tightened Card typing, improved clipboard/keyboard accessibility in Text + Colors stories, made header hover tooltips decorative-only for screen readers, added MIT LICENSE, and stopped tracking local `.claude/settings.local.json`.

--- a/specs/.meta.json
+++ b/specs/.meta.json
@@ -1,0 +1,5 @@
+{
+  "source": "https://github.com/NoahWright87/spec-template",
+  "commit": "93cbaa1ff0944a142e5eb2d1148ba97b2c4487a8",
+  "date": "2026-03-12"
+}

--- a/specs/.spec.md
+++ b/specs/.spec.md
@@ -1,51 +1,51 @@
-# Specs Directory — Meta Spec
+# Specs Directory — Current State
 
 ## Purpose
-This file describes the specs directory itself: its structure, conventions, and the relationship between specs, todo files, and tests. It is a meta-document for anyone authoring or reviewing specs.
+This document describes how the `specs/` directory is organized in this repository and how it supports spec-driven development for the design system.
 
 ## Related
-- [Design System Root Spec](design-system.spec.md)
-- [Spec Template](~template.spec.md)
+- [Root spec](spec.md)
+- [Specs README](README.md)
+- [Directory roadmap](.spec.todo.md)
 
 ## Contract
 
 ### Inputs
-- New spec files and todo files authored by contributors.
-- Updates to existing specs as components evolve.
+- New and updated spec files under `specs/`.
+- New and updated roadmap files (`spec.todo.md` and `{feature}.todo.md`).
+- Implementation changes in `src/`, `stories/`, and related areas that require spec updates.
 
 ### Outputs
-- A consistent, navigable collection of specs that serve as the source of truth for implementation and testing.
+- A consistent spec tree that documents current behavior and future plans.
+- Clear routing targets for intake/refine workflows.
+- Testable acceptance criteria for key behaviors.
 
 ### Guarantees / Constraints
-- Every component, atom, example, and page has a corresponding spec file.
-- Every spec has an adjacent todo file for future work.
-- Specs reflect current intent; todo files track future intent.
+- Specs describe current behavior; roadmap files track future work.
+- Related links point to spec files rather than todo files.
+- Large topics are split into focused specs when they outgrow root docs.
 
 ## Behavior
+When behavior changes in code, the corresponding spec is updated in the same session. New work starts as roadmap items and moves into current-state specs when implemented.
 
-When a new component or feature is planned, a spec is written first. When work is complete, the spec is updated to reflect the final design. When future ideas arise, they are added to the todo file and promoted into the spec before implementation begins.
+> **TODO:** Add a concise map from major source areas (`src/components`, `src/sites`, `stories/examples`) to their expected spec locations.
 
 ## Interface
 
-### Directory Structure
-- `atoms/` — specs for design tokens (motion, shadows, colors, etc.)
-- `components/molecules/` — specs for small reusable UI components.
-- `components/organisms/` — specs for composed UI structures.
-- `examples/` — specs for full-page composition examples.
-- `labs/` — specs for experimental or tooling pages.
-- `sites/` — specs for site-level pages (portfolio, etc.)
+### Directory intent
+- `atoms/` holds foundational tokens and low-level behavior specs.
+- `components/` holds reusable component specs.
+- `examples/` holds composed-page and integration specs.
+- `labs/` holds experimental and prototype specs.
+- `sites/` holds site-level experience specs.
+- `deps/` holds external dependency context and outbound todo routing.
 
-### File Naming
-- `[name].spec.md` — the spec for a given component, atom, page, or example.
-- `[name].spec.todo.md` — the todo list for future work on that subject.
-- `~template.spec.md` — the spec template to copy when creating a new spec.
-- `~template.spec.todo.md` — the todo template to copy alongside every new spec.
-
-### Spec Format
-Every spec follows the template structure: Purpose, Related, Contract, Behavior, Interface, and Acceptance. See the template for section descriptions.
+### File conventions
+- `spec.md` is the root current-state spec for a scope.
+- `spec.todo.md` is the root roadmap for a scope.
+- `{feature}.spec.md` and `{feature}.todo.md` are focused companions for larger topics.
 
 ## Acceptance
-1. Every subject has a corresponding spec file following the template.
-2. Every spec has an adjacent todo file with Sooner/Later/Backlog sections.
-3. All acceptance criteria in specs are testable and intent-based.
-4. Todo items are promoted into specs before implementation.
+- The directory-level spec reflects this repository’s structure and workflow.
+- Conventions in this file match the current templates used in `specs/`.
+- Unknown details are tracked with explicit `> **TODO:**` placeholders.

--- a/specs/.spec.todo.md
+++ b/specs/.spec.todo.md
@@ -1,17 +1,13 @@
-# Specs Directory — Todo
+# Specs Directory — Roadmap
 
 ## Sooner
-- [x] Add `ToggleIcon` molecule spec: Two-state animated icon toggle. See `specs/components/molecules/toggleicon/toggleicon.todo.md`.
-- [x] Document boolean prop API convention: Props that are off by default use positive names (`isSticky`, `hasBottomSeparator`); those that are on by default use negative opt-outs (`noGutters`). Both work as shorthand — no `={true}` needed.
+- Normalize remaining legacy spec naming conventions where needed so all new work follows `spec.md` + `spec.todo.md` patterns.
+- Add the source-to-spec routing map referenced in [`.spec.md`](.spec.md).
 
 ## Later
-- [x] Add `Box` molecule for simple content wrappers.
-- [ ] Add `Icon` molecule with SVG-based icon support.
-- [x] Add `Badge` molecule for compact notification indicators.
+- Add a lightweight quality checklist for spec updates (contract completeness, related links, and acceptance clarity).
+- Audit high-traffic specs for line-length split readiness.
 
 ## Backlog
-- [ ] Add form organism with validation helpers.
-- [ ] Add Table or data grid organism.
-- [ ] Add Pagination control organism.
-- [x] Add Breadcrumbs navigation organism.
-- [ ] Add Sidebar layout organism.
+- Add guidance for cross-cutting specs that span multiple component folders.
+- Add examples of good acceptance criteria for visual vs interaction behavior.

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -1,0 +1,86 @@
+# Specs — Agent Instructions
+
+This directory uses **spec-driven development**. Specs are the source of truth; code implements them.
+
+## Structure
+
+- Specs live in `specs/` and mirror the source tree.
+- Every directory in `specs/` includes:
+  - `spec.md` — current, shippable behavior
+  - `spec.todo.md` — future work and roadmap
+- Additional focused specs are named `{feature}.spec.md` and follow the same structure as `spec.md`.
+- Every spec includes a **Related** section linking to other spec files (not TODOs).
+
+## Workflow
+
+1. Start new work in `spec.todo.md`.
+2. Once a TODO item is implemented, promote its description into `spec.md`.
+3. Keep specs and code in sync — when behavior changes, update the spec alongside the code.
+
+## Writing specs
+
+- Describe behavior, not implementation
+- Be explicit where ambiguity could cause bugs
+- Keep specs short, readable, and skimmable
+- Future or uncommitted behavior belongs in `spec.todo.md`, not `spec.md`
+
+## Split rule
+
+Applies to both spec files and TODO spec files.
+
+- Split a spec when it grows past **300 lines**.
+- A spec at **500 lines** must be split before further work continues.
+- A single large or complex idea in `spec.todo.md` warrants its own `{feature}.todo.md` — use size thresholds as a guide, but also use judgment: if an idea has enough sub-concerns to benefit from its own space, extract it.
+- A refined `{feature}.todo.md` functions as a PRD or HLD, all in-repo. When implemented, it graduates to `{feature}.spec.md`.
+
+## Evolving conventions
+
+The spec system grows to capture the team's actual conventions — not just the template defaults.
+
+While writing or reviewing specs, notice repeated corrections from the user. When the same pattern is corrected twice or more, suggest adding it as a new bullet in the Writing specs section of this file (`specs/AGENTS.md`). Capture team habits where agents will actually read them.
+
+## Incomplete specs
+
+When a spec section cannot be determined from available context, mark it with a `> **TODO:**` placeholder:
+
+```markdown
+> **TODO:** Why does this module exist? Who depends on it?
+```
+
+This format renders visibly in GitHub, is greppable (`> \*\*TODO\*\*`), and signals clearly that the section needs attention. Fill a placeholder whenever context allows — even a partial answer is better than leaving it blank. Run `/spec-backfill` at any time to scan for remaining placeholders and check overall spec completeness.
+
+## Dependency specs
+
+The `specs/deps/` directory holds specs and outbound TODO files for repositories this project depends on.
+
+- `specs/deps/{name}.spec.md` — outsider knowledge: what the dep does from our perspective, why we use it, how we interface with it, owner, known quirks. Written for routing, not integration docs.
+- `specs/deps/{name}.todo.md` — outbound work items; "implementing" one means opening a GitHub issue in that repo. `/knock-out-todos` opens the downstream issue and records it as a sub-bullet on the TODO item.
+- Sub-bullet format for cross-repo issues: `  - [{repo}#{N}](url)` — added by `/knock-out-todos` after opening the downstream issue.
+- When all sub-bullet issues are closed, the main item is unblocked. Once validated, move it to `spec.md` and drop the sub-bullets — they are implementation history, not current state.
+
+See [`deps/README.md`](deps/README.md) for templates.
+
+## Comments explain why, not what
+
+This applies to code comments, spec annotations, and inline notes throughout the codebase.
+
+Code already says what it does. A comment that merely restates the code adds noise. A comment that explains *why* — the constraint, the history, the non-obvious reason — adds signal.
+
+- Write `# WHY: ltrimstr removes only one char; test() handles multi-space/newline prefixes` rather than `# fix whitespace`
+- Write `# WHY: credential helper is scoped to github.com to avoid leaking the token to other hosts` rather than `# scope credential helper`
+- When code is self-explanatory, omit the comment — the best comment is often none at all
+
+## Language
+
+Write specs in the affirmative. Describe what the system does. When a constraint is necessary, pair it with the positive form — "prefer X over Y" rather than "avoid Y." See [PHILOSOPHY.md](../PHILOSOPHY.md) for rationale.
+
+## Reminders
+
+- `spec.md` = current state — `spec.todo.md` = future plans — `{feature}.todo.md` = elaborated plans / PRDs
+- Completed items flow from todo → `spec.md` when implemented
+- Large ideas flow from `spec.todo.md` → their own `{feature}.todo.md` when they need room to grow
+- Write in the affirmative; pair every constraint with its positive form
+
+---
+
+*Installed by [spec-template](https://github.com/NoahWright87/spec-template).*

--- a/specs/INTAKE.md
+++ b/specs/INTAKE.md
@@ -1,12 +1,12 @@
 # Ideas intake
 
-Too lazy to search for the right spec to update?  Throw your idea here and let the LLMs put it in the right place(s) later!
+Not sure where your idea belongs? Drop it here and let the LLMs file it in the right place later!
 
 ## AGENTS Instructions
 
-When asked to, take any items listed below and organize put them into the appropriate TODO spec file.  Ideas may be vague, rambling, or half-baked.  If necessary, ask clarifying questions to determine what the user's intent was.  If a single item refers to multiple components or is a particularly large/complex idea, it can be broken into multiple separate TODOs in the relevant `*.todo.spec`.
+When asked to, take any items listed below and put them into the appropriate `.todo.md` file. Ideas may be vague, rambling, or half-baked. If necessary, ask clarifying questions to determine the user's intent. If a single item refers to multiple components or is a particularly large/complex idea, break it into multiple TODOs across the relevant `.todo.md` files.
 
-If a requested item already exists in the TODO spec, that implies a higher priority.  Tell the user and ask if they want to add any details or move it higher in the TODO spec.
+Use your best judgement to determine the priority of each item. If a requested item already exists in the TODO spec, that implies a higher priority. If a high priority item is lacking details, always ask the user for more information. When priority is unclear, ask the user.
 
 When you have emptied the submissions section below, leave behind a single bullet:
 
@@ -14,11 +14,8 @@ When you have emptied the submissions section below, leave behind a single bulle
 - *Add your ideas here*.
 ```
 
+Items waiting for more information stay in this file with a date annotation: `*(waiting for response, asked YYYY-MM-DD)*`. Re-surface stale items after **7 days** with no reply — change this number to adjust the threshold. If the user asks to defer an item, annotate it as `*(snoozed until YYYY-MM-DD)*` and skip it until that date.
+
 ## Submissions
 
-- BUG: Modal backdrop doesn't cover the full screen.  There's a bit still visible on the left.
-- Can modals have scrolling content?
-- Modal closing animation?
-- TODOs that are checked off should be removed before committing.
-- Could we make INTAKE work from GH issues as well as the intake form?  That way people don't have to commit and potentially get a PR approved just to have their TODO item added.
-    - Would need some sort of approval step at work so that the bot only picks up items the team has agreed with.  Otherwise people could submit issues to other peoples' projects.
+- *Add your ideas here*.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,96 +1,46 @@
-# Specs — Source of Truth
+# Specs
 
-This directory contains human-readable, plain Markdown specifications that define the intended behavior and appearance of components and composed examples. These specs are the source of truth for tests and for implementation work.
-
-## Purpose
-- Describe current behavior (as-is) of existing components and examples.
-- Serve as instructions for implementation and refinement by an LLM and by engineers.
-- Drive tests: acceptance criteria in specs should be directly validated by automated tests (e.g., Playwright visual and interaction tests).
+This directory contains **spec-driven source-of-truth documents** for this repository.
+Specs mirror the source tree and describe *what the system is and how it behaves*, not how it is implemented.
 
 ## Core rules
-- Each spec directory has a root spec and a neighboring todo spec.
-	- In this repo, root specs are typically named `<name>.spec.md` with a matching `<name>.todo.md`.
-- Additional specs use `{feature}.spec.md` and follow the same structure as the root spec.
-- Specs describe current, shippable behavior; future work belongs in the todo spec.
-- Every spec includes a **Related** section that links only to other specs (no todo links).
-- If a spec grows beyond 300 lines, it should be split. If it reaches 500 lines, it must be split.
+- `spec.md` is the **root spec** for each directory.
+- Every `spec.md` must have a neighboring `spec.todo.md`.
+- Additional specs are named `{feature}.spec.md` and use the same template.
+- Specs must include a **Related** section that links only to other specs (not TODOs).
 
-## Keeping specs current — mandatory rule
+## File types
 
-**Every time a prop, behavior, or visual state is added or changed in a component, the corresponding spec file must be updated in the same session.** The spec is the source of truth; a spec that lags behind the code is actively misleading.
+### `spec.md`
+Primary specification for a page, feature, system, or module.
+Describes the **current, shippable contract**.
 
-Minimum updates required when a component changes:
+### `{feature}.spec.md`
+Focused spec for a sub-feature or component.
+Same structure as `spec.md`, just smaller in scope.
 
-| What changed | What to update in the spec |
-|---|---|
-| New prop added | Add it to **Contract → Inputs** with its type and default |
-| New behavioral state | Add a paragraph to **Behavior** |
-| New visual state | Add a note to **Interface** |
-| Any of the above | Add a numbered criterion to **Acceptance** |
+### `spec.todo.md`
+Roadmap for future work related to its neighboring spec.
+Prioritized from top to bottom.
 
-A new prop that is implemented but not documented in the spec is a documentation bug. There are no acceptable shortcuts here — if you implement it, you spec it.
+### `{feature}.todo.md`
+Elaborated plan for a specific feature or idea — extracted from `spec.todo.md` when an item grows large or complex enough to warrant its own space. Functions as a PRD or HLD, all in-repo. When implemented, it graduates to `{feature}.spec.md`.
 
-## Directory Structure
-- `.spec.md` — Root spec describing the entire system and atomic design philosophy.
-- `components/` — Per-component specs (e.g., `button/button.spec.md`).
-- `examples/` — Higher-level, composed example specs (e.g., `address-form.md`, `portfolio-site.md`). Use these to describe multi-component pages or flows.
+INTAKE can seed a `{feature}.todo.md` directly when a submitted idea is substantial enough to open a refinement conversation rather than file as a simple bullet.
 
-## Folder & Naming Conventions
-- Components follow their atomic level implicitly via composition; we do not enforce directory prefixes for atoms/molecules/organisms at this time.
-- Specs live under `specs/components/<name>/*.md` and examples under `specs/examples/*.md`.
-- Each component has a `.spec.md` for current behavior and a `.todo.md` for future backlog items.
-- Root philosophy and design decisions live in `.spec.md` and `.spec.todo.md`.
+### `deps/`
+Specs and outbound TODO files for repositories this project depends on. Each dep gets a `{name}.spec.md` (outsider knowledge — what it does from our perspective, why we use it) and optionally a `{name}.todo.md` (work items that need to happen in that repo). See [`deps/README.md`](deps/README.md) for templates and the full pattern.
 
-## Authoring Conventions
-- Format: Plain Markdown.
-- Scope: Describe the current behavior/appearance (not future aspirations). Capture future ideas in a per-component backlog file (`*.todo.md`).
-- Source-of-truth: Acceptance Criteria sections define what tests must verify. Tests should map to these criteria explicitly.
-- Be specific but pragmatic: Prefer intent-based assertions over pixel-perfect expectations to allow platform differences.
-- Use the template in `specs/~template.spec.md` for new specs and ensure each spec includes a **Related** section.
+## Split rule
 
-### Backlog Files (`*.todo.md`)
-- Purpose: Store future enhancements, half-baked ideas, and under-described features for each component.
-- Location: Place next to the component spec (e.g., `components/button/button.todo.md`).
-- Content: Bulleted lists with brief rationale and rough acceptance ideas; not binding until promoted into the main spec.
-- Reference: Link to the backlog from the component spec.
+Applies to both spec files and TODO spec files.
 
-## Component Spec Template
-Each component spec should generally include:
+- Split when a file grows past **300 lines**.
+- A file at **500 lines** must be split before further work continues.
+- Use judgment for TODO files too: if a single idea has enough sub-concerns to benefit from its own space, extract it into `{feature}.todo.md` before hitting the line limits.
 
-1. Overview
-	- Purpose and brief implementation summary.
-	- Design system integration, if any.
-2. API
-	- Props and their types/semantics.
-	- DOM shape and key attributes.
-3. Visuals
-	- Default appearance and any variants/sizes, if implemented.
-4. Interactions
-	- Pointer, keyboard, focus, and any stateful behaviors.
-5. Accessibility
-	- Names, roles, ARIA, focus order, and assistive behavior.
-6. Constraints & Non-Goals
-	- What is explicitly not supported today.
-7. Acceptance Criteria (Tests)
-	- Numbered, testable statements the suite should validate.
-8. Current Example & Test Mapping
-	- Reference relevant stories and test baselines (e.g., visual snapshots).
-9. Future Extensions (Aspirational)
-	- Brief list of planned/possible enhancements (not yet implemented).
-
-See [components/button/button.spec.md](components/button/button.spec.md) for a complete example.
-
-## Tests Integration
-- Visual tests should validate presence and intent, not pixel perfection. Tolerate minor platform differences.
-- Interaction tests should cover activation, focus management, keyboard support, and state changes spelled out in Acceptance Criteria.
-- Keep test names and snapshots aligned with spec sections for traceability.
-
-## Sketches & Diagrams (Optional)
-- You may embed rough sketches or diagrams in example specs to convey layout/intent. Tests should compare overall intent (structure and key affordances), not exact pixels.
-
-## Review & Evolution
-- Start with current behavior. When requirements change, update the spec first, then adjust implementation and tests to match.
-- Keep specs concise; prefer clear bullet points and numbered criteria over prose.
-
-## Notes
-- Storybook example pages live under `stories/examples/` in the codebase; specs for multi-component compositions live here under `specs/examples/` to define intent and acceptance.
+## Writing guidelines
+- Prefer **behavior over implementation**
+- Be explicit where ambiguity could cause bugs
+- Keep specs short, readable, and skimmable
+- If it's not current behavior, it belongs in `spec.todo.md`

--- a/specs/deps/README.md
+++ b/specs/deps/README.md
@@ -1,0 +1,46 @@
+# Dependency Specs
+
+The `deps/` directory holds specs and outbound TODO files for repositories this project depends on.
+
+## Files
+
+- **`{name}.spec.md`** — outsider knowledge about the dep: what it does from our perspective, why we use it, how we interface with it, who owns it, known quirks. Written for routing — enough context for an agent or new teammate to understand the dep without digging into its codebase.
+- **`{name}.todo.md`** — work items that need to happen *in that repo*. "Implementing" one of these means opening a GitHub issue there. `/knock-out-todos` handles that step and records the downstream issue as a sub-bullet on the TODO item.
+
+## Dep spec template
+
+```markdown
+# {Dep Name}
+
+**What it does:** What this dep is for, from our perspective — the problem it solves for us.
+**Why we use it:** Why it was chosen; what gap it fills; any history worth knowing.
+**Interface:** How we call it (REST API, npm package, event bus, shared DB, etc.)
+**Owner:** Team or person responsible for the dep.
+**GitHub:** [link](url)
+**Notes:** Quirks, gotchas, or limitations we've discovered through use.
+```
+
+## Dep TODO format
+
+```markdown
+# {Dep Name} — Outbound TODOs
+
+Work that needs to happen in [{dep name}]({github url}).
+"Implementing" a TODO here means opening a GitHub issue in that repo.
+
+- [ ] [#local-issue](url) Description of what needs to happen in {dep name}
+  - [{dep-name}#{N}]({url}) ← downstream issue, added by /knock-out-todos once opened
+```
+
+When `/knock-out-todos` picks up a dep TODO, it:
+1. Opens a GitHub issue in the target repo
+2. Adds a sub-bullet with the downstream issue link
+3. Cross-links both issues with comments for traceability
+
+When all sub-bullet dep issues are closed, the main item is unblocked. Once validated/implemented, it moves to `spec.md` — without the sub-bullets, which are implementation history, not current state.
+
+## Reminders
+
+- Dep specs describe *our relationship* to the dep, not the dep's internal design
+- Keep dep specs short — just enough to route work confidently
+- Outbound TODOs go in `{name}.todo.md`; changes to *our* codebase go in the regular `spec.todo.md`

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,49 +1,41 @@
-# Spec Template — Current State
+# Design System — Root Spec
 
 ## Purpose
-
-A two-product system for spec-driven development: an installable scaffold that gives AI a persistent memory in any repo, and an optional autonomous worker container that runs the intake/TODO workflow on a schedule.
+This repository defines a reusable React design system with Storybook examples, theme tokens, and supporting specs that guide implementation and testing.
 
 ## Related
+- [`design-system.spec.md`](design-system.spec.md)
+- [`README.md`](README.md)
+- [`spec.todo.md`](spec.todo.md)
 
-- [`scaffold.md`](scaffold.md) — Layer 1 current state (scaffold files, dist/ generation)
-- [`worker.md`](worker.md) — Layer 2 current state (worker container, modes, CI/CD)
-- [`scaffold.todo.md`](scaffold.todo.md) — future scaffold and dist/ work
-- [`worker.todo.md`](worker.todo.md) — future worker runtime work
-- [`spec.todo.md`](spec.todo.md) — meta-tooling improvements (commands, UX)
+## Contract
 
-## System Overview
+### Inputs
+- Component props from consumers of the package.
+- Theme tokens and CSS custom properties under `styles/`.
+- Story definitions under `stories/` for examples and visual coverage.
 
-The system has two independent layers. A repo can use Layer 1 without ever running Layer 2.
+### Outputs
+- Rendered UI components and composed example pages.
+- Published library exports from `src/index.ts`.
+- Storybook documentation and visual baselines.
 
-**Layer 1 — Installable scaffold:** a small set of files (spec templates, AI slash commands, a PR check workflow) that downstream repos copy in via `/respec` or from `dist/`. Gives AI a persistent spec memory in the target repo. See [`scaffold.md`](scaffold.md).
+### Guarantees / Constraints
+- Specs are the source of truth for intended behavior.
+- Components remain SSR-safe by guarding browser-only APIs at runtime.
+- Unknown or undecided behavior is called out with explicit placeholders.
 
-**Layer 2 — Autonomous worker:** a Docker container that clones a target repo, detects whether the scaffold is installed, and either bootstraps it (install mode) or runs the intake/TODO workflow (operate mode) on a cron schedule. See [`worker.md`](worker.md).
+## Behavior
+The system provides atoms, molecules, and organisms with consistent styling and composability.
 
-## Commands
+> **TODO:** Summarize current behavior by major areas (forms, layout, navigation, feedback) with links to component-level specs.
 
-- `/intake` (Steps 1–8): Ensure INTAKE.md exists → check waiting/snoozed items → pull from GitHub Issues → read `auto_create_issues` config from `specs/.meta.json` (controls whether manual submissions later get auto-filed as GH issues; absent = asks user) → read Submissions → survey TODO spec files → process each item (route/boost/ask) → selectively clear INTAKE.md → report
-  - **Auto-create GH issues:** opt-in via `"auto_create_issues": true` in `specs/.meta.json`; if the key is absent, `/intake` asks the user. When enabled and `gh` is authenticated, creates a GH issue for each unlinked manual submission and labels it `intake:filed`. Off by default.
+## Interface
+Consumers import components and styles from the package and configure appearance through design tokens.
 
-- `/refine` (Steps 1–6): Find highest-priority TODO items → re-check waiting items for new GH responses → load GH issue + spec context → assess clarity and estimate effort → write technical detail and estimates → commit and open PR
-  - **Effort estimates:** XS / S / M / L / XL / Unknown — added inline as `*(effort: M)*` on the TODO item
-  - **Supervised mode:** iterates with user in chat until sign-off, then commits and opens PR
-  - **Headless mode:** posts clarifying questions to GH issues for unresolved product decisions, adds best-effort technical detail, commits and opens PR automatically; picks up GH replies on the next run
+> **TODO:** Document package-consumer ergonomics (default styling model, override model, and expected integration steps).
 
-## Scripts
-
-- `scripts/generate-dist.sh` — regenerates `dist/` from scaffold source files; run after modifying any scaffold source
-- `scripts/install-scaffold.sh <target>` — copies `dist/` scaffold files into a target repo without overwriting existing files; faster/cheaper alternative to running `/respec` with Claude for the deterministic file-copy step
-- `scripts/generate-roadmap.sh` — generates `docs/ROADMAP.md` from all `specs/**/*.todo.md` files; groups open items by area with links back to individual spec files; suitable for GH Pages publishing
-- `.github/workflows/pages.yml` — publishes `docs/` and `specs/` to GitHub Pages on push to main; regenerates roadmap before upload
-
-## Human-Facing Docs
-
-- `README.md` is the human entrypoint; Quick Start (onboarding command) appears first before any background explanation
-- AI-facing instructions live in `.claude/commands/` and `specs/AGENTS.md` — not in the README
-
-## Guarantees / Constraints
-
-- Scaffold files in `dist/` are auto-generated from source — edit sources, run `scripts/generate-dist.sh`, commit result
-- Worker supports two auth modes: Claude Code subscription (mount `~/.claude`) or Anthropic API key (`ANTHROPIC_API_KEY`); never bake credentials into the image
-- Worker state volume is a supporting cache; GitHub and the target repo are the primary system of record
+## Acceptance
+- Root spec reflects this repository’s current purpose and constraints.
+- Root spec avoids references to unrelated repositories.
+- Unknown details are tracked with actionable `> **TODO:**` placeholders until refined.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,0 +1,49 @@
+# Spec Template — Current State
+
+## Purpose
+
+A two-product system for spec-driven development: an installable scaffold that gives AI a persistent memory in any repo, and an optional autonomous worker container that runs the intake/TODO workflow on a schedule.
+
+## Related
+
+- [`scaffold.md`](scaffold.md) — Layer 1 current state (scaffold files, dist/ generation)
+- [`worker.md`](worker.md) — Layer 2 current state (worker container, modes, CI/CD)
+- [`scaffold.todo.md`](scaffold.todo.md) — future scaffold and dist/ work
+- [`worker.todo.md`](worker.todo.md) — future worker runtime work
+- [`spec.todo.md`](spec.todo.md) — meta-tooling improvements (commands, UX)
+
+## System Overview
+
+The system has two independent layers. A repo can use Layer 1 without ever running Layer 2.
+
+**Layer 1 — Installable scaffold:** a small set of files (spec templates, AI slash commands, a PR check workflow) that downstream repos copy in via `/respec` or from `dist/`. Gives AI a persistent spec memory in the target repo. See [`scaffold.md`](scaffold.md).
+
+**Layer 2 — Autonomous worker:** a Docker container that clones a target repo, detects whether the scaffold is installed, and either bootstraps it (install mode) or runs the intake/TODO workflow (operate mode) on a cron schedule. See [`worker.md`](worker.md).
+
+## Commands
+
+- `/intake` (Steps 1–8): Ensure INTAKE.md exists → check waiting/snoozed items → pull from GitHub Issues → read `auto_create_issues` config from `specs/.meta.json` (controls whether manual submissions later get auto-filed as GH issues; absent = asks user) → read Submissions → survey TODO spec files → process each item (route/boost/ask) → selectively clear INTAKE.md → report
+  - **Auto-create GH issues:** opt-in via `"auto_create_issues": true` in `specs/.meta.json`; if the key is absent, `/intake` asks the user. When enabled and `gh` is authenticated, creates a GH issue for each unlinked manual submission and labels it `intake:filed`. Off by default.
+
+- `/refine` (Steps 1–6): Find highest-priority TODO items → re-check waiting items for new GH responses → load GH issue + spec context → assess clarity and estimate effort → write technical detail and estimates → commit and open PR
+  - **Effort estimates:** XS / S / M / L / XL / Unknown — added inline as `*(effort: M)*` on the TODO item
+  - **Supervised mode:** iterates with user in chat until sign-off, then commits and opens PR
+  - **Headless mode:** posts clarifying questions to GH issues for unresolved product decisions, adds best-effort technical detail, commits and opens PR automatically; picks up GH replies on the next run
+
+## Scripts
+
+- `scripts/generate-dist.sh` — regenerates `dist/` from scaffold source files; run after modifying any scaffold source
+- `scripts/install-scaffold.sh <target>` — copies `dist/` scaffold files into a target repo without overwriting existing files; faster/cheaper alternative to running `/respec` with Claude for the deterministic file-copy step
+- `scripts/generate-roadmap.sh` — generates `docs/ROADMAP.md` from all `specs/**/*.todo.md` files; groups open items by area with links back to individual spec files; suitable for GH Pages publishing
+- `.github/workflows/pages.yml` — publishes `docs/` and `specs/` to GitHub Pages on push to main; regenerates roadmap before upload
+
+## Human-Facing Docs
+
+- `README.md` is the human entrypoint; Quick Start (onboarding command) appears first before any background explanation
+- AI-facing instructions live in `.claude/commands/` and `specs/AGENTS.md` — not in the README
+
+## Guarantees / Constraints
+
+- Scaffold files in `dist/` are auto-generated from source — edit sources, run `scripts/generate-dist.sh`, commit result
+- Worker supports two auth modes: Claude Code subscription (mount `~/.claude`) or Anthropic API key (`ANTHROPIC_API_KEY`); never bake credentials into the image
+- Worker state volume is a supporting cache; GitHub and the target repo are the primary system of record

--- a/specs/spec.todo.md
+++ b/specs/spec.todo.md
@@ -1,24 +1,24 @@
-# Spec Template — Roadmap
+# Design System — Roadmap
 
 ## Summary
-This repo provides two products: (1) an installable spec / intake / TODO scaffold for other repos, and (2) a reusable autonomous worker runtime that runs Claude CLI in a container. See `scaffold.todo.md` and `worker.todo.md` for the large feature work. This file tracks improvements to the template system itself (commands, UX, meta-tooling).
+This file tracks future work for the design system itself: component completeness, spec quality, Storybook quality, and release readiness.
 
 ## Sooner
+- Fill missing root-spec details called out in [`spec.md`](spec.md) placeholders.
+- Audit top-priority component specs to ensure inputs/behavior/acceptance stay aligned with current code.
 
 ## Later
-
-### Reduce cognitive load for humans
-- [#4](https://github.com/NoahWright87/spec-template/issues/4) Audit commands and consider combining or routing via a meta `/help` command so humans have less to remember
+- Improve examples under `stories/examples/` to cover full-page integration patterns.
+- Expand test mapping between acceptance criteria and visual/interaction checks.
 
 ## Backlog
+- Add a lightweight release checklist spec for versioning, changelog curation, and publish validation.
+- Add dependency relationship notes in `specs/deps/` where external libraries need explicit routing context.
 
 ## Ideas (Uncommitted)
-
-- When `/respec` runs in Update mode, compare the `dist/specs/spec.todo.md` template against the local TODO files. If the format differs (e.g. checkboxes vs plain bullets), offer to migrate existing TODO items to the current format. Apply only with user approval.
+- Evaluate whether root-level specs should mirror the source tree more strictly for faster navigation.
 
 ## Reminders
-
-- Move completed items to `spec.md` — this file is for future plans, not current state
-- Large or complex ideas belong in their own `{feature}.todo.md`, not buried here
-- Items flow: INTAKE → `spec.todo.md` → `{feature}.todo.md` (if big) → `spec.md` (when done)
-- If a TODO item links to a GH issue (`[#N](...)`), include `closes #N` in your PR description — GitHub closes the issue on merge
+- Move implemented roadmap items into current-state specs.
+- Keep large ideas in focused `{feature}.todo.md` files when they outgrow this list.
+- Keep entries concise and prioritized from top to bottom within each section.

--- a/specs/spec.todo.md
+++ b/specs/spec.todo.md
@@ -1,0 +1,24 @@
+# Spec Template — Roadmap
+
+## Summary
+This repo provides two products: (1) an installable spec / intake / TODO scaffold for other repos, and (2) a reusable autonomous worker runtime that runs Claude CLI in a container. See `scaffold.todo.md` and `worker.todo.md` for the large feature work. This file tracks improvements to the template system itself (commands, UX, meta-tooling).
+
+## Sooner
+
+## Later
+
+### Reduce cognitive load for humans
+- [#4](https://github.com/NoahWright87/spec-template/issues/4) Audit commands and consider combining or routing via a meta `/help` command so humans have less to remember
+
+## Backlog
+
+## Ideas (Uncommitted)
+
+- When `/respec` runs in Update mode, compare the `dist/specs/spec.todo.md` template against the local TODO files. If the format differs (e.g. checkboxes vs plain bullets), offer to migrate existing TODO items to the current format. Apply only with user approval.
+
+## Reminders
+
+- Move completed items to `spec.md` — this file is for future plans, not current state
+- Large or complex ideas belong in their own `{feature}.todo.md`, not buried here
+- Items flow: INTAKE → `spec.todo.md` → `{feature}.todo.md` (if big) → `spec.md` (when done)
+- If a TODO item links to a GH issue (`[#N](...)`), include `closes #N` in your PR description — GitHub closes the issue on merge


### PR DESCRIPTION
## Summary
- apply spec-template managed files in adaptation mode
- add managed command docs: /respec, /refine, /spec-backfill
- add spec coverage workflow and specs metadata file
- align existing INTAKE and TODO command docs to template conventions
- ignore and remove temporary .tmp artifacts used during setup

## Notes
- source template commit: 93cbaa1ff0944a142e5eb2d1148ba97b2c4487a8
- CHANGELOG updated under WIP