### PR TITLE
Knock out completed spec todos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
+- **Todo pass:** Added Colors contrast/export helpers and Motion Lab preset shortcuts, reset, easing copy feedback, and multi-format export options while promoting those todos into current specs.
+
 - **Todo/spec cleanup:** Promoted completed Colors copy, Contact Form validation, Header Responsive theme persistence/transition/shortcut, and Nonsense customization items into current specs; cleaned completed entries from todo files.
 
 - **Container/Card/Button backlog pass:** Container now supports alignment shortcuts and flex item controls (`alignItems`, `justifyContent`, `centered`, `spaceBetween`, `grow`, `shrink`, `basis`, `wrap`, `fullWidth`), Card supports full-surface `href` links, and Button supports a loading spinner with `aria-busy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
+- **Todo/spec cleanup:** Promoted completed Colors copy, Contact Form validation, Header Responsive theme persistence/transition/shortcut, and Nonsense customization items into current specs; cleaned completed entries from todo files.
+
 - **Container/Card/Button backlog pass:** Container now supports alignment shortcuts and flex item controls (`alignItems`, `justifyContent`, `centered`, `spaceBetween`, `grow`, `shrink`, `basis`, `wrap`, `fullWidth`), Card supports full-surface `href` links, and Button supports a loading spinner with `aria-busy`.
 
 - **Intake routing:** Filed motion feature requests [#12] and [#13] into the Motion Lab backlog under a new Motion Primitives section in `specs/labs/motion.todo.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
+- **Motion Lab accessibility/export pass:** Added Tailwind animation-config export plus animated, focusable, screen-reader-described easing graphs.
+
 - **Todo pass:** Added Colors contrast/export helpers and Motion Lab preset shortcuts, reset, easing copy feedback, and multi-format export options while promoting those todos into current specs.
 
 - **Todo/spec cleanup:** Promoted completed Colors copy, Contact Form validation, Header Responsive theme persistence/transition/shortcut, and Nonsense customization items into current specs; cleaned completed entries from todo files.

--- a/specs/atoms/nonsense.spec.md
+++ b/specs/atoms/nonsense.spec.md
@@ -16,6 +16,7 @@ It is an atom in the atomic design sense: a non-rendering, zero-dependency utili
 - Optional `seed` — a string for reproducible random selection across calls.
 - Optional `customEntries` — an array of strings that replaces the built-in pool for array-based categories. Ignored for function-based categories (`abstractImage`, `date`).
 - Optional `weights` — an array of relative weights, same length as the active pool. Higher values increase the likelihood of that entry being selected. Ignored for function-based categories.
+- Emoji-focused category names can be requested the same way as text-focused categories.
 
 ### Outputs
 - A single random string from the requested category, or an array of strings if a count is requested.
@@ -40,6 +41,8 @@ When called with a category name, the atom returns a random entry from that cate
 
 **With weights:** Entries are selected using weighted probability — a weight of `3` for an entry makes it three times as likely as an entry with weight `1`. If the weights array length does not match the pool length, weights are silently ignored and uniform random selection is used.
 
+**Emoji-only categories:** Emoji-focused categories return compact emoji strings for playful placeholder states such as moods or skills.
+
 **Date category:** Accepts optional range constraints and returns a realistic date or date range formatted naturally (for example, "Jan 2024 – Sep 2025").
 
 **Image category:** Returns a minimal abstract SVG suitable for use as an image source.
@@ -63,7 +66,7 @@ When called with a category name, the atom returns a random entry from that cate
 - Project names, skill names, service names, testimonial quotes, accomplishments.
 
 **Utility:**
-- Intro text, call-to-action text, fictional social platform names, abstract images, and date ranges.
+- Intro text, call-to-action text, fictional social platform names, abstract images, emoji-focused categories, and date ranges.
 
 ### Usage
 The atom exposes a single function that accepts a category name and returns a random entry. Callers may request multiple entries at once or supply a seed for reproducible results.
@@ -80,3 +83,4 @@ The atom exposes a single function that accepts a category name and returns a ra
 9. Providing `customEntries` replaces the built-in pool for that call.
 10. Providing `weights` of the correct length biases selection toward higher-weighted entries.
 11. Providing `weights` of the wrong length falls back silently to uniform random selection.
+12. Emoji-only categories return emoji strings suitable for compact placeholder content.

--- a/specs/atoms/nonsense.todo.md
+++ b/specs/atoms/nonsense.todo.md
@@ -5,8 +5,5 @@
 
 ## Later
 - [ ] Localization support — placeholder categories in other languages.
-- [x] Custom palettes — allow callers to supply their own entry lists per category.
-- [x] Weighted randomness — allow some entries to appear more or less frequently.
 
 ## Backlog
-- [x] Emoji-only categories (for example, mood or skill emojis).

--- a/specs/examples/colors.spec.md
+++ b/specs/examples/colors.spec.md
@@ -12,7 +12,7 @@ The Colors example displays all theme color tokens as labeled swatches, giving d
 The current theme's color tokens, read from the computed styles of the rendered page.
 
 ### Outputs
-A grid of color swatches, each showing the token's name and resolved color value. Clicking a swatch copies its token name to the clipboard and briefly confirms the action.
+A grid of color swatches, each showing the token's name, resolved color value, contrast ratios, and exportable token values. Clicking a swatch copies its token name to the clipboard and briefly confirms the action.
 
 ### Guarantees / Constraints
 - One swatch is rendered per defined color token.
@@ -22,11 +22,15 @@ A grid of color swatches, each showing the token's name and resolved color value
 
 On load, the page reads the resolved value of each color token from the page's computed styles and builds a swatch for each.
 
+**Contrast display:** Each swatch shows contrast ratios against the foreground and background tokens when the browser provides parseable computed color values.
+
 **Copying token names:** Each swatch acts as a button. Clicking a swatch copies the token name to the clipboard and temporarily changes the label to confirm the copy.
+
+**Exporting values:** The page provides export text for the resolved token values in CSS custom property and JSON formats, with a copy action for the selected format.
 
 ## Interface
 
-A titled page with a flexible wrapping grid of color swatches. Each swatch shows a solid block of the token's color above its name and resolved value. Swatches wrap horizontally to fill available space.
+A titled page with an export panel above a flexible wrapping grid of color swatches. Each swatch shows a solid block of the token's color, contrast information, token name, and resolved value. Swatches wrap horizontally to fill available space.
 
 This page is a developer and designer reference tool, not a user-facing feature.
 
@@ -38,3 +42,7 @@ This page is a developer and designer reference tool, not a user-facing feature.
 5. Missing or unresolved tokens display a graceful fallback.
 6. Clicking a swatch copies the token name to the clipboard.
 7. A copied swatch briefly displays confirmation feedback.
+8. Each swatch displays contrast ratios for foreground and background comparisons when values are parseable.
+9. The export panel can show token values as CSS custom properties.
+10. The export panel can show token values as JSON.
+11. The selected export format can be copied to the clipboard.

--- a/specs/examples/colors.spec.md
+++ b/specs/examples/colors.spec.md
@@ -12,7 +12,7 @@ The Colors example displays all theme color tokens as labeled swatches, giving d
 The current theme's color tokens, read from the computed styles of the rendered page.
 
 ### Outputs
-A grid of color swatches, each showing the token's name and resolved color value.
+A grid of color swatches, each showing the token's name and resolved color value. Clicking a swatch copies its token name to the clipboard and briefly confirms the action.
 
 ### Guarantees / Constraints
 - One swatch is rendered per defined color token.
@@ -20,7 +20,9 @@ A grid of color swatches, each showing the token's name and resolved color value
 
 ## Behavior
 
-On load, the page reads the resolved value of each color token from the page's computed styles and builds a swatch for each. The display is static — there are no interactions.
+On load, the page reads the resolved value of each color token from the page's computed styles and builds a swatch for each.
+
+**Copying token names:** Each swatch acts as a button. Clicking a swatch copies the token name to the clipboard and temporarily changes the label to confirm the copy.
 
 ## Interface
 
@@ -34,3 +36,5 @@ This page is a developer and designer reference tool, not a user-facing feature.
 3. Each swatch displays the token name and its resolved color value.
 4. Swatches arrange in a wrapping grid layout.
 5. Missing or unresolved tokens display a graceful fallback.
+6. Clicking a swatch copies the token name to the clipboard.
+7. A copied swatch briefly displays confirmation feedback.

--- a/specs/examples/colors.todo.md
+++ b/specs/examples/colors.todo.md
@@ -4,7 +4,5 @@
 - [ ] TBD
 
 ## Later
-- [ ] Contrast checker overlay for each swatch.
 
 ## Backlog
-- [ ] Export color values in various formats.

--- a/specs/examples/colors.todo.md
+++ b/specs/examples/colors.todo.md
@@ -5,7 +5,6 @@
 
 ## Later
 - [ ] Contrast checker overlay for each swatch.
-- [x] Copy-to-clipboard for token names.
 
 ## Backlog
 - [ ] Export color values in various formats.

--- a/specs/examples/contact-form.spec.md
+++ b/specs/examples/contact-form.spec.md
@@ -15,15 +15,18 @@ The Contact Form example composes all four form primitive components — Input, 
 User interaction with form fields — typing, selecting, checking, and submitting.
 
 ### Outputs
-A complete, interactive contact form page. Form submission shows a browser alert for illustration purposes. Canceling does not submit.
+A complete, interactive contact form page. Form submission validates required fields and shows a browser alert for illustration purposes when valid. Canceling does not submit.
 
 ### Guarantees / Constraints
 - All form controls are functional — input, selection, and checkbox state all work.
 - The Cancel button does not trigger form submission.
+- Required fields present validation feedback both during field interaction and form submission.
 
 ## Behavior
 
-The page renders a centered form card with all four form control types. Users can interact with each control independently. Submitting the form triggers an illustrative response. Canceling leaves the form unchanged.
+The page renders a centered form card with all four form control types. Users can interact with each control independently. Submitting the form validates all required fields together. When any required field is invalid, every invalid field enters its error state in the same submit attempt. When required fields are valid, submitting triggers an illustrative response. Canceling leaves the form unchanged.
+
+**Inline required validation:** A required field that receives input and is then cleared shows its error state before the next submit attempt.
 
 ## Interface
 
@@ -47,3 +50,5 @@ Action buttons appear at the bottom of the form, right-aligned. The submit butto
 6. Submitting the form triggers the submit handler.
 7. The cancel button does not trigger submission.
 8. The layout is readable on narrow viewports.
+9. Submitting with multiple invalid required fields shows all required-field errors at once.
+10. Clearing a required field after entering text shows inline validation feedback.

--- a/specs/examples/contact-form.todo.md
+++ b/specs/examples/contact-form.todo.md
@@ -1,8 +1,6 @@
 # Contact Form — Todo
 
 ## Sooner
-- [x] Show all validation errors at once: On submit, put all invalid fields into error state simultaneously — not just the first one.
-- [x] Required field inline validation: Fields should show error state when typed into and then cleared, not only on submit.
 
 ## Later
 - [ ] TBD

--- a/specs/examples/header-responsive.spec.md
+++ b/specs/examples/header-responsive.spec.md
@@ -10,7 +10,7 @@ The Header Responsive example demonstrates the header's label-hiding behavior on
 ## Contract
 
 ### Inputs
-User interaction: resizing the viewport, clicking the theme toggle.
+User interaction: resizing the viewport, clicking the theme toggle, and using the theme toggle keyboard shortcut.
 
 ### Outputs
 Two variants showing responsive label hiding and a functional light/dark theme toggle.
@@ -18,12 +18,14 @@ Two variants showing responsive label hiding and a functional light/dark theme t
 ### Guarantees / Constraints
 - Labels are always hidden on small screens regardless of their content.
 - Theme switching takes effect immediately without a page reload.
+- Theme preference persists across page loads.
+- Theme changes animate smoothly when motion preferences allow it.
 
 ## Behavior
 
 **Label hiding:** Labels configured in header slots are visible on larger screens and hidden on smaller screens. Only the slot content (icon or element) remains visible on small screens.
 
-**Theme toggle:** A button in the right slot toggles between light and dark themes. The current theme is reflected by the button's icon and the page's background color.
+**Theme toggle:** A button in the right slot toggles between light and dark themes. The current theme is reflected by the button's icon and the page's background color. The selected theme is saved so subsequent page loads restore the same preference. Switching themes applies a short color transition when motion preferences allow it. The theme can also be toggled with the keyboard shortcut shown by the example.
 
 **Variant 1:** Left slot has an icon and app-name label. Center has a page label. Right has a theme toggle.
 
@@ -39,3 +41,6 @@ On desktop-sized viewports, labels are visible alongside slot content. On mobile
 3. The theme toggle changes the page theme when clicked.
 4. The toggle icon updates to reflect the current theme.
 5. The center menu in variant 2 opens and closes correctly.
+6. Theme preference persists across page loads.
+7. Theme changes use smooth color transitions when motion preferences allow it.
+8. The keyboard shortcut toggles the current theme.

--- a/specs/examples/header-responsive.todo.md
+++ b/specs/examples/header-responsive.todo.md
@@ -4,9 +4,6 @@
 - [ ] TBD
 
 ## Later
-- [x] Persistent theme preference across page loads.
-- [x] Smooth transitions when switching themes.
 
 ## Backlog
-- [x] Keyboard shortcut for theme toggle.
 - [ ] Mobile drawer menu alternative to the dropdown overlay.

--- a/specs/labs/motion.spec.md
+++ b/specs/labs/motion.spec.md
@@ -16,7 +16,7 @@ Motion Lab is an interactive playground for designing and tuning component anima
 
 ### Outputs
 - A live preview of the component with the current motion values applied.
-- A generated export reflecting the current settings, ready to copy and paste as component CSS, CSS custom properties, SCSS variables, or design token JSON.
+- A generated export reflecting the current settings, ready to copy and paste as component CSS, CSS custom properties, SCSS variables, Tailwind animation config, or design token JSON.
 
 ### Guarantees / Constraints
 - One adapter per story — multiple adapters in the same story are not supported.
@@ -34,6 +34,8 @@ Motion Lab is an interactive playground for designing and tuning component anima
 
 **Copying exports:** The current export is copied to the clipboard and a brief confirmation is shown. Individual easing readouts can also be copied from their easing sections.
 
+**Reading easing graphs:** Easing graphs show an animated progress marker along the curve. The graph can receive keyboard focus and exposes a short screen reader description of the curve's shape.
+
 **Current adapters:**
 - **Button** — controls hover lift, press scale and squish, and timing curves for press and release.
 - **Modal** — controls enter and exit duration, easing curves, and transform type (fade, scale-fade, slide-fade).
@@ -46,9 +48,9 @@ The lab is organized into three main areas:
 
 **Sticky preview:** The live component, always visible as the user scrolls through controls.
 
-**Controls panel:** Preset selector at the top, then grouped knob sections below. Sliders control numeric values; dropdowns select named options; toggles switch boolean settings. Easing knobs include a visual curve graph alongside the sliders.
+**Controls panel:** Preset selector at the top, then grouped knob sections below. Sliders control numeric values; dropdowns select named options; toggles switch boolean settings. Easing knobs include a visual curve graph with an animated playhead alongside the sliders.
 
-**Generated export:** A read-only text area at the bottom showing the selected export format, with a format selector and copy button. Supported formats are component CSS, CSS custom properties, SCSS variables, and design token JSON.
+**Generated export:** A read-only text area at the bottom showing the selected export format, with a format selector and copy button. Supported formats are component CSS, CSS custom properties, SCSS variables, Tailwind animation config, and design token JSON.
 
 On small screens, the control grid collapses to a single column.
 
@@ -60,10 +62,13 @@ On small screens, the control grid collapses to a single column.
 5. The preview component updates in real time as values change.
 6. The generated CSS updates live and matches the preview.
 7. The copy button copies the selected export to the clipboard and shows brief feedback.
-8. The export selector switches between component CSS, CSS custom properties, SCSS variables, and design token JSON.
+8. The export selector switches between component CSS, CSS custom properties, SCSS variables, Tailwind animation config, and design token JSON.
 9. The sticky preview remains visible while scrolling through the controls panel.
 10. The Button adapter renders a button with motion applied; bounce and squish presets work.
 11. The Modal adapter renders a modal with enter and exit animations; the transform type selector works.
 12. Ctrl+number shortcuts select presets in dropdown order.
 13. The reset button restores the currently selected preset's values.
 14. Each easing section copy button copies that easing function and shows brief feedback.
+15. Easing graphs show an animated playhead that follows the curve.
+16. Easing graphs show a visible focus state when focused by keyboard.
+17. Easing graphs expose a screen reader description of the current curve shape.

--- a/specs/labs/motion.spec.md
+++ b/specs/labs/motion.spec.md
@@ -16,7 +16,7 @@ Motion Lab is an interactive playground for designing and tuning component anima
 
 ### Outputs
 - A live preview of the component with the current motion values applied.
-- A generated CSS snippet reflecting the current settings, ready to copy and paste.
+- A generated export reflecting the current settings, ready to copy and paste as component CSS, CSS custom properties, SCSS variables, or design token JSON.
 
 ### Guarantees / Constraints
 - One adapter per story — multiple adapters in the same story are not supported.
@@ -28,11 +28,11 @@ Motion Lab is an interactive playground for designing and tuning component anima
 
 **Opening the lab:** The lab renders with the default preset applied and all knobs set to the preset's values.
 
-**Selecting a preset:** All knobs update to the preset's values and the preview refreshes immediately.
+**Selecting a preset:** All knobs update to the preset's values and the preview refreshes immediately. Presets can be selected from the dropdown or with Ctrl+number shortcuts in preset order.
 
-**Adjusting a knob:** The preview updates as the knob changes; the generated CSS updates to match.
+**Adjusting a knob:** The preview updates as the knob changes; the generated export updates to match. The reset button reapplies the currently selected preset values after manual knob changes.
 
-**Copying CSS:** The current CSS snippet is copied to the clipboard and a brief confirmation is shown.
+**Copying exports:** The current export is copied to the clipboard and a brief confirmation is shown. Individual easing readouts can also be copied from their easing sections.
 
 **Current adapters:**
 - **Button** — controls hover lift, press scale and squish, and timing curves for press and release.
@@ -48,7 +48,7 @@ The lab is organized into three main areas:
 
 **Controls panel:** Preset selector at the top, then grouped knob sections below. Sliders control numeric values; dropdowns select named options; toggles switch boolean settings. Easing knobs include a visual curve graph alongside the sliders.
 
-**Generated CSS:** A read-only text area at the bottom showing the exportable CSS, with a copy button.
+**Generated export:** A read-only text area at the bottom showing the selected export format, with a format selector and copy button. Supported formats are component CSS, CSS custom properties, SCSS variables, and design token JSON.
 
 On small screens, the control grid collapses to a single column.
 
@@ -59,7 +59,11 @@ On small screens, the control grid collapses to a single column.
 4. Easing curve graphs update visually as bezier knobs change.
 5. The preview component updates in real time as values change.
 6. The generated CSS updates live and matches the preview.
-7. The copy button copies the CSS to the clipboard and shows brief feedback.
-8. The sticky preview remains visible while scrolling through the controls panel.
-9. The Button adapter renders a button with motion applied; bounce and squish presets work.
-10. The Modal adapter renders a modal with enter and exit animations; the transform type selector works.
+7. The copy button copies the selected export to the clipboard and shows brief feedback.
+8. The export selector switches between component CSS, CSS custom properties, SCSS variables, and design token JSON.
+9. The sticky preview remains visible while scrolling through the controls panel.
+10. The Button adapter renders a button with motion applied; bounce and squish presets work.
+11. The Modal adapter renders a modal with enter and exit animations; the transform type selector works.
+12. Ctrl+number shortcuts select presets in dropdown order.
+13. The reset button restores the currently selected preset's values.
+14. Each easing section copy button copies that easing function and shows brief feedback.

--- a/specs/labs/motion.todo.md
+++ b/specs/labs/motion.todo.md
@@ -14,7 +14,6 @@
 
 ### UI & Interaction
 - [ ] Groupable preset categories (e.g., "Professional", "Playful", "Extreme").
-- [ ] Real-time animation playhead on easing graphs (shows progress along curve).
 - [ ] Undo/redo stack for knob changes.
 
 ### Component Adapters
@@ -25,7 +24,6 @@
 - [ ] Toast/Notification motion adapter (slide-in + auto-dismiss).
 
 ### Output Formats
-- [ ] Export as Tailwind animation config (animated utility).
 
 ### Developer Experience
 - [ ] Share preset as URL query string (e.g., `?preset=extreme-bounce`).
@@ -33,9 +31,7 @@
 - [ ] Animation speed multiplier (0.5x–2x playback speed).
 
 ### Accessibility
-- [ ] Focus visible state for easing graph (interactive elements).
 - [ ] Keyboard-draggable bezier control points (instead of sliders).
-- [ ] Screen reader descriptions for easing curve shapes (e.g., "overshoot at top").
 
 ### Testing
 - [ ] Visual regression tests for preset previews.

--- a/specs/labs/motion.todo.md
+++ b/specs/labs/motion.todo.md
@@ -14,10 +14,8 @@
 
 ### UI & Interaction
 - [ ] Groupable preset categories (e.g., "Professional", "Playful", "Extreme").
-- [ ] Keyboard shortcuts for preset selection (Ctrl+1, Ctrl+2, etc.).
 - [ ] Real-time animation playhead on easing graphs (shows progress along curve).
 - [ ] Undo/redo stack for knob changes.
-- [ ] "Reset to preset" button in addition to preset selector.
 
 ### Component Adapters
 - [ ] Link motion adapter (underline, color shift on hover/focus).
@@ -27,13 +25,9 @@
 - [ ] Toast/Notification motion adapter (slide-in + auto-dismiss).
 
 ### Output Formats
-- [ ] Export as SCSS variables (with !default).
-- [ ] Export as CSS custom property definitions (copy into `:root`).
 - [ ] Export as Tailwind animation config (animated utility).
-- [ ] Export as design token JSON (for token studio integration).
 
 ### Developer Experience
-- [ ] Copy individual easing function button (press/release/enter/exit separately).
 - [ ] Share preset as URL query string (e.g., `?preset=extreme-bounce`).
 - [ ] Side-by-side comparison of two presets.
 - [ ] Animation speed multiplier (0.5x–2x playback speed).

--- a/src/labs/motion/MotionLab.tsx
+++ b/src/labs/motion/MotionLab.tsx
@@ -144,7 +144,7 @@ export function MotionLab({ adapter }: MotionLabProps) {
       <Section title={title} key={prefix}>
         <div className={styles.easingGrid}>
           <div className={styles.easingGraphWrap}>
-            <EasingGraph x1={x1Value} y1={y1Value} x2={x2Value} y2={y2Value} />
+            <EasingGraph label={title} x1={x1Value} y1={y1Value} x2={x2Value} y2={y2Value} />
           </div>
           <div className={styles.bezierControls}>
             {adapter?.knobs

--- a/src/labs/motion/MotionLab.tsx
+++ b/src/labs/motion/MotionLab.tsx
@@ -14,6 +14,7 @@ export interface MotionLabProps {
 export function MotionLab({ adapter }: MotionLabProps) {
   const [presetName, setPresetName] = React.useState(adapter.presets[0]?.name ?? "");
   const [values, setValues] = React.useState<MotionValues>({});
+  const [copiedEasing, setCopiedEasing] = React.useState<string | null>(null);
 
   // Initialize values from adapter defaults
   React.useEffect(() => {
@@ -35,8 +36,47 @@ export function MotionLab({ adapter }: MotionLabProps) {
     }
   }, [presetName, adapter]);
 
+  const applyPreset = React.useCallback((name: string) => {
+    const preset = adapter.presets.find((item) => item.name === name);
+
+    if (preset) {
+      setPresetName(name);
+      setValues({ ...preset.values });
+    }
+  }, [adapter]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.ctrlKey || event.metaKey || event.altKey) return;
+
+      const presetIndex = Number(event.key) - 1;
+      const preset = adapter.presets[presetIndex];
+
+      if (!preset) return;
+
+      event.preventDefault();
+      applyPreset(preset.name);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [adapter, applyPreset]);
+
   const handleValueChange = (knobId: string, value: number | string | boolean) => {
     setValues((prev) => ({ ...prev, [knobId]: value }));
+  };
+
+  const handleCopyEasing = (prefix: string, value: string) => {
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      return;
+    }
+
+    navigator.clipboard.writeText(value).then(() => {
+      setCopiedEasing(prefix);
+      setTimeout(() => setCopiedEasing(null), 1500);
+    });
   };
 
   const renderKnob = (knob: MotionKnob) => {
@@ -117,9 +157,9 @@ export function MotionLab({ adapter }: MotionLabProps) {
           <button
             className={styles.readout__copy}
             type="button"
-            onClick={() => navigator.clipboard?.writeText(bezierString)}
+            onClick={() => handleCopyEasing(prefix, bezierString)}
           >
-            Copy
+            {copiedEasing === prefix ? "Copied!" : "Copy"}
           </button>
         </div>
       </Section>
@@ -170,7 +210,14 @@ export function MotionLab({ adapter }: MotionLabProps) {
             onChange={setPresetName}
             options={adapter.presets.map((p) => p.name)}
           />
-          <div className={styles.hint}>Pick a preset, then tweak knobs</div>
+          <button
+            className={styles.readout__copy}
+            type="button"
+            onClick={() => applyPreset(presetName)}
+          >
+            Reset to preset
+          </button>
+          <div className={styles.hint}>Pick a preset, then tweak knobs. Use Ctrl+1, Ctrl+2, etc. to switch presets.</div>
         </Section>
 
         {Object.entries(groupedKnobs).map(([category, knobs]) => (

--- a/src/labs/motion/ui/EasingGraph.module.css
+++ b/src/labs/motion/ui/EasingGraph.module.css
@@ -1,6 +1,12 @@
 .easingGraph {
   width: 100%;
   height: 13.125rem;
+  border-radius: calc(var(--radius) * 0.875);
+  outline: none;
+}
+
+.easingGraph:focus-visible {
+  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--primary);
 }
 
 .eg__bg {
@@ -28,6 +34,12 @@
 .eg__dot {
   fill: var(--foreground);
   opacity: 0.4;
+}
+
+.eg__playhead {
+  fill: var(--confirm);
+  stroke: var(--background);
+  stroke-width: 2;
 }
 
 .eg__p {

--- a/src/labs/motion/ui/EasingGraph.module.css.d.ts
+++ b/src/labs/motion/ui/EasingGraph.module.css.d.ts
@@ -5,6 +5,7 @@ declare const styles: {
   readonly eg__handle: string;
   readonly eg__curve: string;
   readonly eg__dot: string;
+  readonly eg__playhead: string;
   readonly eg__p: string;
   readonly eg__cp: string;
   readonly eg__label: string;

--- a/src/labs/motion/ui/EasingGraph.tsx
+++ b/src/labs/motion/ui/EasingGraph.tsx
@@ -6,6 +6,7 @@ export interface EasingGraphProps {
   y1: number;
   x2: number;
   y2: number;
+  label?: string;
 }
 
 function cubic(a: number, b: number, c: number, d: number, t: number): number {
@@ -13,7 +14,27 @@ function cubic(a: number, b: number, c: number, d: number, t: number): number {
   return mt * mt * mt * a + 3 * mt * mt * t * b + 3 * mt * t * t * c + t * t * t * d;
 }
 
-export function EasingGraph({ x1, y1, x2, y2 }: EasingGraphProps) {
+function describeCurve(y1: number, y2: number) {
+  if (y1 > 1 || y2 > 1) {
+    return "overshoots above the target value";
+  }
+
+  if (y1 < 0 || y2 < 0) {
+    return "dips below the starting value";
+  }
+
+  if (y1 < y2) {
+    return "accelerates into the target value";
+  }
+
+  if (y1 > y2) {
+    return "decelerates into the target value";
+  }
+
+  return "moves evenly toward the target value";
+}
+
+export function EasingGraph({ x1, y1, x2, y2, label = "Easing curve" }: EasingGraphProps) {
   const W = 280;
   const H = 200;
   const xMin = 0;
@@ -30,6 +51,7 @@ export function EasingGraph({ x1, y1, x2, y2 }: EasingGraphProps) {
   const p3 = { x: 1, y: 1 };
 
   const path = `M ${sx(p0.x)} ${sy(p0.y)} C ${sx(p1.x)} ${sy(p1.y)} ${sx(p2.x)} ${sy(p2.y)} ${sx(p3.x)} ${sy(p3.y)}`;
+  const description = `${label}: cubic bezier ${x1}, ${y1}, ${x2}, ${y2}; ${describeCurve(y1, y2)}.`;
 
   const y0 = sy(0);
   const y1line = sy(1);
@@ -44,8 +66,8 @@ export function EasingGraph({ x1, y1, x2, y2 }: EasingGraphProps) {
   }
 
   return (
-    <div className={styles.easingGraph} aria-label="Easing curve graph">
-      <svg viewBox={`0 0 ${W} ${H}`} width="100%" height="100%" role="img">
+    <div className={styles.easingGraph} tabIndex={0} aria-label={description}>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" height="100%" role="img" aria-label={description}>
         <rect x="0" y="0" width={W} height={H} rx="14" ry="14" className={styles.eg__bg} />
         <line x1="0" y1={y0} x2={W} y2={y0} className={styles.eg__grid} />
         <line x1="0" y1={y1line} x2={W} y2={y1line} className={styles.eg__grid} />
@@ -54,6 +76,9 @@ export function EasingGraph({ x1, y1, x2, y2 }: EasingGraphProps) {
         <line x1={sx(p3.x)} y1={sy(p3.y)} x2={sx(p2.x)} y2={sy(p2.y)} className={styles.eg__handle} />
 
         <path d={path} className={styles.eg__curve} />
+        <circle r="5" className={styles.eg__playhead}>
+          <animateMotion dur="1.6s" repeatCount="indefinite" path={path} />
+        </circle>
 
         {pts.map((p, idx) => (
           <circle key={idx} cx={p.x} cy={p.y} r={idx % 4 === 0 ? 2.2 : 1.4} className={styles.eg__dot} />

--- a/src/labs/motion/ui/GeneratedCss.module.css
+++ b/src/labs/motion/ui/GeneratedCss.module.css
@@ -14,6 +14,17 @@
   color: var(--foreground);
   font-size: 0.8125rem;
   opacity: 0.7;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.gen__select {
+  border: 1px solid color-mix(in srgb, var(--foreground) 20%, transparent);
+  background: var(--background);
+  color: var(--foreground);
+  border-radius: calc(var(--radius) * 0.75);
+  padding: 0.375rem 0.5rem;
 }
 
 .gen__copy {

--- a/src/labs/motion/ui/GeneratedCss.module.css.d.ts
+++ b/src/labs/motion/ui/GeneratedCss.module.css.d.ts
@@ -2,6 +2,7 @@ declare const styles: {
   readonly gen: string;
   readonly gen__top: string;
   readonly gen__hint: string;
+  readonly gen__select: string;
   readonly gen__copy: string;
   readonly gen__box: string;
 };

--- a/src/labs/motion/ui/GeneratedCss.tsx
+++ b/src/labs/motion/ui/GeneratedCss.tsx
@@ -5,32 +5,86 @@ export interface GeneratedCssProps {
   cssText: string;
 }
 
+type ExportFormat = "css" | "root" | "scss" | "json";
+
+const formatLabels: Record<ExportFormat, string> = {
+  css: "Component CSS",
+  root: ":root custom properties",
+  scss: "SCSS variables",
+  json: "Design token JSON",
+};
+
+function extractCustomProperties(cssText: string) {
+  return Array.from(cssText.matchAll(/(--[\w-]+):\s*([^;]+);/g)).map((match) => ({
+    name: match[1],
+    value: match[2].trim(),
+  }));
+}
+
+function formatExport(cssText: string, format: ExportFormat) {
+  const tokens = extractCustomProperties(cssText);
+
+  if (format === "root") {
+    return `:root {\n${tokens.map((token) => `  ${token.name}: ${token.value};`).join("\n")}\n}`;
+  }
+
+  if (format === "scss") {
+    return tokens
+      .map((token) => `$${token.name.slice(2)}: ${token.value} !default;`)
+      .join("\n");
+  }
+
+  if (format === "json") {
+    const payload = Object.fromEntries(
+      tokens.map((token) => [token.name.slice(2), { value: token.value, type: "motion" }]),
+    );
+    return JSON.stringify(payload, null, 2);
+  }
+
+  return cssText;
+}
+
 export function GeneratedCss({ cssText }: GeneratedCssProps) {
   const [copied, setCopied] = React.useState(false);
+  const [format, setFormat] = React.useState<ExportFormat>("css");
+  const exportText = React.useMemo(() => formatExport(cssText, format), [cssText, format]);
 
   const handleCopy = async () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      return;
+    }
+
     try {
-      await navigator.clipboard.writeText(cssText);
+      await navigator.clipboard.writeText(exportText);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
+    } catch {
+      setCopied(false);
     }
   };
 
   return (
     <div className={styles.gen}>
       <div className={styles.gen__top}>
-        <div className={styles.gen__hint}>
-          Portable CSS snippet based on current settings
-        </div>
+        <label className={styles.gen__hint}>
+          Export format
+          <select
+            className={styles.gen__select}
+            value={format}
+            onChange={(event) => setFormat(event.target.value as ExportFormat)}
+          >
+            {Object.entries(formatLabels).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </label>
         <button className={styles.gen__copy} type="button" onClick={handleCopy}>
-          {copied ? "Copied!" : "Copy CSS"}
+          {copied ? "Copied!" : "Copy export"}
         </button>
       </div>
       <textarea
         className={styles.gen__box}
-        value={cssText}
+        value={exportText}
         readOnly
         rows={16}
         spellCheck={false}

--- a/src/labs/motion/ui/GeneratedCss.tsx
+++ b/src/labs/motion/ui/GeneratedCss.tsx
@@ -5,12 +5,13 @@ export interface GeneratedCssProps {
   cssText: string;
 }
 
-type ExportFormat = "css" | "root" | "scss" | "json";
+type ExportFormat = "css" | "root" | "scss" | "tailwind" | "json";
 
 const formatLabels: Record<ExportFormat, string> = {
   css: "Component CSS",
   root: ":root custom properties",
   scss: "SCSS variables",
+  tailwind: "Tailwind animation config",
   json: "Design token JSON",
 };
 
@@ -39,6 +40,17 @@ function formatExport(cssText: string, format: ExportFormat) {
       tokens.map((token) => [token.name.slice(2), { value: token.value, type: "motion" }]),
     );
     return JSON.stringify(payload, null, 2);
+  }
+
+  if (format === "tailwind") {
+    const payload = Object.fromEntries(
+      tokens.map((token) => [
+        token.name.slice(2),
+        token.value.replace(/^var\((--[\w-]+)\)$/, "var($1)"),
+      ]),
+    );
+
+    return `theme: {\n  extend: {\n    transitionTimingFunction: ${JSON.stringify(payload, null, 6).replace(/\n/g, "\n    ")}\n  }\n}`;
   }
 
   return cssText;

--- a/stories/examples/Colors.stories.tsx
+++ b/stories/examples/Colors.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Meta } from '@storybook/react';
 import { cssTokenNames } from '../../src/styles/tokens';
 
@@ -7,9 +7,74 @@ export default {
   parameters: { docs: { description: { story: 'Shows color tokens from theme.css' } } },
 } as Meta;
 
+type Rgb = { r: number; g: number; b: number };
+
+function parseRgb(value: string): Rgb | null {
+  const rgbMatch = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+
+  if (rgbMatch) {
+    return {
+      r: Number(rgbMatch[1]),
+      g: Number(rgbMatch[2]),
+      b: Number(rgbMatch[3]),
+    };
+  }
+
+  if (value.startsWith('#') && value.length === 7) {
+    return {
+      r: Number.parseInt(value.slice(1, 3), 16),
+      g: Number.parseInt(value.slice(3, 5), 16),
+      b: Number.parseInt(value.slice(5, 7), 16),
+    };
+  }
+
+  return null;
+}
+
+function luminance({ r, g, b }: Rgb) {
+  const channels = [r, g, b].map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+}
+
+function contrastRatio(a: string, b: string) {
+  const first = parseRgb(a);
+  const second = parseRgb(b);
+
+  if (!first || !second) {
+    return null;
+  }
+
+  const firstLuminance = luminance(first);
+  const secondLuminance = luminance(second);
+  const lighter = Math.max(firstLuminance, secondLuminance);
+  const darker = Math.min(firstLuminance, secondLuminance);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function formatContrast(ratio: number | null) {
+  return ratio ? `${ratio.toFixed(2)}:1` : 'n/a';
+}
+
+function formatCssVariables(colors: Record<string, string>) {
+  const lines = Object.entries(colors).map(([name, value]) => `  ${name}: ${value};`);
+  return `:root {\n${lines.join('\n')}\n}`;
+}
+
+function formatJson(colors: Record<string, string>) {
+  return JSON.stringify(colors, null, 2);
+}
+
 export const ColorGrid = () => {
   const [colors, setColors] = useState<Record<string, string>>({});
   const [copied, setCopied] = useState<string | null>(null);
+  const [exportFormat, setExportFormat] = useState<'css' | 'json'>('css');
 
   useEffect(() => {
     const computed = getComputedStyle(document.documentElement);
@@ -21,19 +86,77 @@ export const ColorGrid = () => {
     setColors(resolved);
   }, []);
 
+  const exportText = useMemo(
+    () => exportFormat === 'css' ? formatCssVariables(colors) : formatJson(colors),
+    [colors, exportFormat],
+  );
+
   function handleCopy(name: string) {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      return;
+    }
+
     navigator.clipboard.writeText(name).then(() => {
       setCopied(name);
       setTimeout(() => setCopied(null), 1500);
     });
   }
 
+  function handleExportCopy() {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      return;
+    }
+
+    navigator.clipboard.writeText(exportText).then(() => {
+      setCopied('export');
+      setTimeout(() => setCopied(null), 1500);
+    });
+  }
+
+  const foreground = colors['--foreground'];
+  const background = colors['--background'];
+
   return (
     <div style={{ padding: 24 }}>
       <h1>Theme colors</h1>
+      <section style={{ marginBottom: 24 }}>
+        <h2>Export values</h2>
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+          <label>
+            Format{' '}
+            <select
+              value={exportFormat}
+              onChange={(event) => setExportFormat(event.target.value as 'css' | 'json')}
+            >
+              <option value="css">CSS custom properties</option>
+              <option value="json">JSON</option>
+            </select>
+          </label>
+          <button type="button" onClick={handleExportCopy}>
+            {copied === 'export' ? 'Copied export!' : 'Copy export'}
+          </button>
+        </div>
+        <textarea
+          value={exportText}
+          readOnly
+          rows={8}
+          spellCheck={false}
+          style={{
+            width: '100%',
+            marginTop: 12,
+            border: '1px solid var(--overlay)',
+            borderRadius: 8,
+            background: 'var(--background)',
+            color: 'var(--foreground)',
+            fontFamily: 'monospace',
+          }}
+        />
+      </section>
       <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
         {Object.entries(colors).map(([name, value]) => {
           const isCopied = copied === name;
+          const foregroundContrast = contrastRatio(value, foreground);
+          const backgroundContrast = contrastRatio(value, background);
           return (
             <button
               type="button"
@@ -58,7 +181,30 @@ export const ColorGrid = () => {
                 background: 'var(--background)',
               }}
             >
-              <div style={{ height: 120, background: value }} />
+              <div
+                style={{
+                  minHeight: 120,
+                  background: value,
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  padding: 8,
+                }}
+              >
+                <div
+                  style={{
+                    width: '100%',
+                    padding: 8,
+                    borderRadius: 6,
+                    background: 'var(--overlay)',
+                    color: 'var(--background)',
+                    fontSize: 12,
+                    fontWeight: 600,
+                  }}
+                >
+                  <div>vs foreground: {formatContrast(foregroundContrast)}</div>
+                  <div>vs background: {formatContrast(backgroundContrast)}</div>
+                </div>
+              </div>
               <div style={{ padding: 12 }}>
                 <div
                   style={{

--- a/stories/examples/Colors.stories.tsx
+++ b/stories/examples/Colors.stories.tsx
@@ -49,11 +49,11 @@ export const ColorGrid = () => {
                 width: 220,
                 display: 'block',
                 textAlign: 'left',
-                border: '1px solid #eee',
+                border: '1px solid var(--overlay)',
                 borderRadius: 8,
                 overflow: 'hidden',
                 cursor: 'pointer',
-                outline: isCopied ? '2px solid var(--primary, #2563eb)' : undefined,
+                outline: isCopied ? '2px solid var(--primary)' : undefined,
                 transition: 'outline 0.15s',
                 background: 'var(--background)',
               }}
@@ -63,7 +63,7 @@ export const ColorGrid = () => {
                 <div
                   style={{
                     fontSize: 12,
-                    color: isCopied ? 'var(--primary, #2563eb)' : '#666',
+                    color: isCopied ? 'var(--primary)' : 'var(--secondary)',
                     fontWeight: isCopied ? 600 : undefined,
                     transition: 'color 0.15s',
                   }}


### PR DESCRIPTION
### Motivation
- Clean up and promote recently completed todo items so specs reflect implemented behavior.
- Keep `specs/*.todo.md` focused on future work by removing completed entries.
- Make the PR easier to validate in GitHub and preview builds by listing the changed surfaces to check.

### Description
- Promoted completed todo items into current specs for Colors, Contact Form, Header Responsive, Nonsense, and Motion Lab.
- Removed completed checklist entries from the corresponding todo files so remaining todo files track future work only.
- Updated the Colors Storybook example to use design-system color tokens instead of hardcoded fallback colors.
- Added Colors contrast-ratio readouts against foreground/background tokens.
- Added a Colors export panel with CSS custom properties and JSON output, plus copy feedback.
- Added Motion Lab preset keyboard shortcuts (`Ctrl+1`, `Ctrl+2`, etc.) and a **Reset to preset** action.
- Added copy feedback for individual Motion Lab easing readouts.
- Added Motion Lab export format switching for component CSS, `:root` custom properties, SCSS variables with `!default`, Tailwind animation config, and design token JSON.
- Added animated Motion Lab easing graph playheads, keyboard focus styling, and screen-reader curve descriptions.
- Updated `CHANGELOG.md` under `## WIP` for the todo/spec cleanup batches.

### Things to check in preview
- **Colors story:** swatches still render all theme tokens, use token styling, and copy token names with visible confirmation.
- **Colors contrast:** each swatch shows foreground/background contrast ratios, with graceful `n/a` behavior if a value cannot be parsed.
- **Colors export:** the export panel switches between CSS custom properties and JSON, the textarea updates, and **Copy export** shows confirmation.
- **Motion Lab presets:** choosing a preset updates all knobs and preview values.
- **Motion Lab shortcuts:** `Ctrl+1`, `Ctrl+2`, etc. switch presets in dropdown order without breaking normal controls.
- **Motion Lab reset:** changing knobs and then clicking **Reset to preset** restores the selected preset values.
- **Motion Lab easing copy:** individual easing copy buttons copy the easing string and briefly show **Copied!**.
- **Motion Lab exports:** export format selector switches between Component CSS, `:root` custom properties, SCSS variables, Tailwind animation config, and design token JSON; **Copy export** copies the selected output.
- **Motion Lab easing graphs:** each graph shows an animated playhead moving along the curve.
- **Motion Lab graph focus:** tabbing to an easing graph shows a visible focus ring.
- **Motion Lab graph accessibility:** focused/read graph labels describe the bezier values and curve shape.
- **Contact Form spec parity:** the spec now documents all-at-once required-field errors and inline validation after clearing a field.
- **Header Responsive spec parity:** the spec now documents persisted theme preference, smooth theme transitions, and keyboard shortcut behavior.
- **Nonsense spec parity:** the spec now documents emoji-focused categories.
- **Todo cleanup:** completed items were removed from the relevant `.todo.md` files while future work remains.

### Testing
- `npm run typecheck` completed successfully after the latest Motion Lab batch.
- `npm run build` completed successfully after the latest Motion Lab batch.
- `npm run build-storybook` completed successfully in the previous local verification pass.
- Playwright screenshot capture could not be completed in the earlier environment because the browser executable was unavailable and `npx playwright install chromium` hit a CDN `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a246174c6b4832eb822f1d248891cf4)