### PR TITLE
Card mediaPosition prop + new Tooltip component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
-- **Tooltip (new molecule):** Floating tooltip that shows on hover, keyboard focus, or touch. `placement` (top/bottom/left/right), `delay`/`hideDelay`, `disabled`, and arbitrary `content`. Fade+scale animation respecting `prefers-reduced-motion`; touch shows immediately and auto-dismisses. Closes #5.
+- **Tooltip (new molecule):** Floating tooltip that shows on hover, keyboard focus, or touch. `placement` (top/bottom/left/right), `delay`/`hideDelay`, `disabled`, and arbitrary `content`. Fade+scale animation respecting `prefers-reduced-motion`; touch shows immediately and auto-dismisses. Basic building block toward #5 — modifier-key reveal behavior from that issue is not yet implemented.
 
 - **Card media position:** Card gains a `mediaPosition` prop (`"top" | "left" | "right"`) so the image can sit beside the body instead of only above it; collapses back to top at 480px. Closes #8.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
+- **Tooltip (new molecule):** Floating tooltip that shows on hover, keyboard focus, or touch. `placement` (top/bottom/left/right), `delay`/`hideDelay`, `disabled`, and arbitrary `content`. Fade+scale animation respecting `prefers-reduced-motion`; touch shows immediately and auto-dismisses. Closes #5.
+
 - **Card media position:** Card gains a `mediaPosition` prop (`"top" | "left" | "right"`) so the image can sit beside the body instead of only above it; collapses back to top at 480px. Closes #8.
 
 - **Container/Card/Button backlog pass:** Container now supports alignment shortcuts and flex item controls (`alignItems`, `justifyContent`, `centered`, `spaceBetween`, `grow`, `shrink`, `basis`, `wrap`, `fullWidth`), Card supports full-surface `href` links, and Button supports a loading spinner with `aria-busy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
+- **Card media position:** Card gains a `mediaPosition` prop (`"top" | "left" | "right"`) so the image can sit beside the body instead of only above it; collapses back to top at 480px. Closes #8.
+
 - **Container/Card/Button backlog pass:** Container now supports alignment shortcuts and flex item controls (`alignItems`, `justifyContent`, `centered`, `spaceBetween`, `grow`, `shrink`, `basis`, `wrap`, `fullWidth`), Card supports full-surface `href` links, and Button supports a loading spinner with `aria-busy`.
 
 - **Intake routing:** Filed motion feature requests [#12] and [#13] into the Motion Lab backlog under a new Motion Primitives section in `specs/labs/motion.todo.md`.

--- a/src/components/molecules/Tooltip/index.tsx
+++ b/src/components/molecules/Tooltip/index.tsx
@@ -1,0 +1,113 @@
+"use client";
+import * as React from "react";
+import { useEffect, useId, useRef, useState } from "react";
+import "./tooltip.css";
+
+export type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+export interface TooltipProps {
+  /** Trigger content. Hover, keyboard focus, or touch on this reveals the tooltip. */
+  children: React.ReactNode;
+  /** Tooltip body content. Accepts any node, not just plain text. */
+  content: React.ReactNode;
+  /** Which side of the trigger the tooltip renders on. Default: `"top"`. */
+  placement?: TooltipPlacement;
+  /** Delay in ms before showing on hover/focus. Default: `300`. */
+  delay?: number;
+  /** Delay in ms before hiding once hover/focus ends. Default: `0`. */
+  hideDelay?: number;
+  /** Disable the tooltip entirely; renders children unmodified. */
+  disabled?: boolean;
+  /** Additional class name for the trigger wrapper. */
+  className?: string;
+}
+
+// How long a touch-revealed tooltip stays up before auto-dismissing.
+const TOUCH_AUTO_HIDE_MS = 2500;
+
+export function Tooltip({
+  children,
+  content,
+  placement = "top",
+  delay = 300,
+  hideDelay = 0,
+  disabled = false,
+  className = "",
+}: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const tooltipId = useId();
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+  const showTimer = useRef<ReturnType<typeof setTimeout>>();
+  const hideTimer = useRef<ReturnType<typeof setTimeout>>();
+  const touchTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const clearTimers = () => {
+    clearTimeout(showTimer.current);
+    clearTimeout(hideTimer.current);
+    clearTimeout(touchTimer.current);
+  };
+
+  useEffect(() => clearTimers, []);
+
+  const scheduleShow = () => {
+    clearTimeout(hideTimer.current);
+    showTimer.current = setTimeout(() => setOpen(true), delay);
+  };
+
+  const scheduleHide = () => {
+    clearTimeout(showTimer.current);
+    hideTimer.current = setTimeout(() => setOpen(false), hideDelay);
+  };
+
+  const handleTouchStart = () => {
+    clearTimers();
+    setOpen(true);
+    touchTimer.current = setTimeout(() => setOpen(false), TOUCH_AUTO_HIDE_MS);
+  };
+
+  // Tapping anywhere outside dismisses a touch-revealed tooltip early.
+  useEffect(() => {
+    if (!open) return;
+    const onDocTouch = (e: TouchEvent) => {
+      const anchor = anchorRef.current;
+      if (anchor && e.target instanceof Node && !anchor.contains(e.target)) {
+        clearTimeout(touchTimer.current);
+        setOpen(false);
+      }
+    };
+    document.addEventListener("touchstart", onDocTouch);
+    return () => document.removeEventListener("touchstart", onDocTouch);
+  }, [open]);
+
+  if (disabled) return <>{children}</>;
+
+  return (
+    <span
+      ref={anchorRef}
+      className={["nw-tooltip__anchor", className].filter(Boolean).join(" ")}
+      aria-describedby={tooltipId}
+      onMouseEnter={scheduleShow}
+      onMouseLeave={scheduleHide}
+      onFocus={scheduleShow}
+      onBlur={scheduleHide}
+      onTouchStart={handleTouchStart}
+    >
+      {children}
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className={[
+          "nw-tooltip",
+          `nw-tooltip--${placement}`,
+          open && "nw-tooltip--visible",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {content}
+      </span>
+    </span>
+  );
+}
+
+export default Tooltip;

--- a/src/components/molecules/Tooltip/tooltip.css
+++ b/src/components/molecules/Tooltip/tooltip.css
@@ -1,0 +1,65 @@
+.nw-tooltip__anchor {
+  position: relative;
+  display: inline-block;
+}
+
+.nw-tooltip {
+  position: absolute;
+  z-index: 50;
+  max-width: 220px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: calc(var(--radius) * 0.5);
+  background: var(--foreground);
+  color: var(--background);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: 1.4;
+  text-align: left;
+  white-space: normal;
+  box-shadow: var(--shadow-sm);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-in-out), transform var(--duration-fast) var(--ease-in-out);
+}
+
+.nw-tooltip--top {
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.92);
+}
+
+.nw-tooltip--bottom {
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.92);
+}
+
+.nw-tooltip--left {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.92);
+}
+
+.nw-tooltip--right {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.92);
+}
+
+.nw-tooltip--top.nw-tooltip--visible,
+.nw-tooltip--bottom.nw-tooltip--visible {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+}
+
+.nw-tooltip--left.nw-tooltip--visible,
+.nw-tooltip--right.nw-tooltip--visible {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nw-tooltip {
+    transition: none;
+  }
+}

--- a/src/components/organisms/Card/Card.tsx
+++ b/src/components/organisms/Card/Card.tsx
@@ -5,9 +5,17 @@ import "./card.css";
  * Card props for a simple elevated, rounded container.
  * Renders as a semantic article with optional title/subtitle and children content.
  */
+export type CardMediaPosition = "left" | "right" | "top";
+
 export interface CardProps extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
   /** Optional media element rendered above the title. */
   image?: React.ReactNode;
+  /**
+   * Where the `image` is placed relative to the title/content/footer.
+   * `"left"` and `"right"` collapse to `"top"` on small screens.
+   * Default: `"top"`.
+   */
+  mediaPosition?: CardMediaPosition;
   /** Optional URL that makes the entire card clickable. */
   href?: string;
   /** Optional card title. */
@@ -48,21 +56,25 @@ export function Card({
   interactive = false,
   scrollable = false,
   maxHeight,
+  mediaPosition = "top",
   className = "",
   ...rest
 }: CardProps) {
+  const isSideMedia = Boolean(image) && mediaPosition !== "top";
+
   const cls = [
     "nw-card",
     elevated && !flat && "nw-card--elevated",
     interactive && "nw-card--interactive",
+    isSideMedia && `nw-card--media-${mediaPosition}`,
     className,
   ]
     .filter(Boolean)
     .join(" ");
 
-  const content = (
+  const body = (
     <>
-      {image ? <div className="nw-card__image">{image}</div> : null}
+      {!isSideMedia && image ? <div className="nw-card__image">{image}</div> : null}
       {title ? <div className="nw-card__title">{title}</div> : null}
       {subtitle ? <div className="nw-card__subtitle">{subtitle}</div> : null}
       {children ? (
@@ -81,6 +93,13 @@ export function Card({
       {footer ? <div className="nw-card__footer">{footer}</div> : null}
     </>
   );
+
+  const content = isSideMedia ? (
+    <>
+      <div className="nw-card__image nw-card__media">{image}</div>
+      <div className="nw-card__body">{body}</div>
+    </>
+  ) : body;
 
   if (href) {
     return (

--- a/src/components/organisms/Card/card.css
+++ b/src/components/organisms/Card/card.css
@@ -43,6 +43,44 @@
   object-fit: cover;
 }
 
+.nw-card--media-left,
+.nw-card--media-right {
+  display: flex;
+  align-items: stretch;
+  gap: 16px;
+}
+
+.nw-card--media-right {
+  flex-direction: row-reverse;
+}
+
+.nw-card--media-left .nw-card__media,
+.nw-card--media-right .nw-card__media {
+  flex: 0 0 40%;
+  margin-bottom: 0;
+  aspect-ratio: auto;
+}
+
+.nw-card--media-left .nw-card__body,
+.nw-card--media-right .nw-card__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+@media (max-width: 480px) {
+  .nw-card--media-left,
+  .nw-card--media-right {
+    flex-direction: column;
+  }
+
+  .nw-card--media-left .nw-card__media,
+  .nw-card--media-right .nw-card__media {
+    flex-basis: auto;
+    margin-bottom: 12px;
+    aspect-ratio: 16 / 9;
+  }
+}
+
 .nw-card__subtitle {
   font-size: 0.875rem;
   color: color-mix(in srgb, var(--foreground, #000) 70%, transparent);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export * from "./components/molecules/RadioGroup/index.js";
 export * from "./components/molecules/ToggleIcon/index.js";
 export * from "./components/molecules/Badge/index.js";
 export * from "./components/molecules/Box/index.js";
+export * from "./components/molecules/Tooltip/index.js";
 
 // Organisms
 export * from "./components/organisms/Header/index.js";

--- a/stories/Card.stories.tsx
+++ b/stories/Card.stories.tsx
@@ -35,6 +35,11 @@ const meta: Meta<typeof Card> = {
       control: "text",
       description: "Optional footer content",
     },
+    mediaPosition: {
+      control: "radio",
+      options: ["top", "left", "right"],
+      description: "Position of the image relative to the card body. left/right collapse to top on small screens.",
+    },
     interactive: {
       control: "boolean",
       description: "Enable hover lift and shadow transition",
@@ -77,6 +82,38 @@ export const WithImage: Story = {
         subtitle="Top media section"
       >
         The image sits above the title and content.
+      </Card>
+    </div>
+  ),
+};
+
+export const MediaLeft: Story = {
+  name: "Media position — left",
+  render: () => (
+    <div style={{ width: 480 }}>
+      <Card
+        image={<img src={getNonsense("abstractImage") as string} alt="Abstract card visual" />}
+        mediaPosition="left"
+        title="Card with Left Media"
+        subtitle="Media sits beside the content"
+      >
+        On small screens this collapses back to a top-positioned image.
+      </Card>
+    </div>
+  ),
+};
+
+export const MediaRight: Story = {
+  name: "Media position — right",
+  render: () => (
+    <div style={{ width: 480 }}>
+      <Card
+        image={<img src={getNonsense("abstractImage") as string} alt="Abstract card visual" />}
+        mediaPosition="right"
+        title="Card with Right Media"
+        subtitle="Media sits beside the content"
+      >
+        On small screens this collapses back to a top-positioned image.
       </Card>
     </div>
   ),

--- a/stories/Tooltip.stories.tsx
+++ b/stories/Tooltip.stories.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Tooltip, Button } from "../src";
+
+const meta: Meta<typeof Tooltip> = {
+  title: "Components/Molecules/Tooltip",
+  component: Tooltip,
+  tags: ["autodocs"],
+  argTypes: {
+    placement: { control: "select", options: ["top", "bottom", "left", "right"] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ padding: "3rem" }}>
+      <Tooltip content="Saves your changes">
+        <Button>Hover me</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Placements: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "3rem", padding: "3rem" }}>
+      <Tooltip content="Appears above" placement="top">
+        <Button variant="outline">Top</Button>
+      </Tooltip>
+      <Tooltip content="Appears below" placement="bottom">
+        <Button variant="outline">Bottom</Button>
+      </Tooltip>
+      <Tooltip content="Appears to the left" placement="left">
+        <Button variant="outline">Left</Button>
+      </Tooltip>
+      <Tooltip content="Appears to the right" placement="right">
+        <Button variant="outline">Right</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const KeyboardAccessible: Story = {
+  name: "keyboard focus",
+  render: () => (
+    <div style={{ padding: "3rem" }}>
+      <Tooltip content="Tab to me to see the tooltip on focus">
+        <Button>Tab to focus</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const CustomDelay: Story = {
+  name: "custom show/hide delay",
+  render: () => (
+    <div style={{ padding: "3rem" }}>
+      <Tooltip content="Shows instantly, lingers for a second" delay={0} hideDelay={1000}>
+        <Button variant="ghost">No show delay, slow hide</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const RichContent: Story = {
+  render: () => (
+    <div style={{ padding: "3rem" }}>
+      <Tooltip
+        content={
+          <>
+            <strong>Pro tip:</strong> tooltips can hold more than plain text.
+          </>
+        }
+      >
+        <Button variant="text">Hover for rich content</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const WrappingNonButtonContent: Story = {
+  name: "wrapping arbitrary content",
+  render: () => (
+    <div style={{ padding: "3rem" }}>
+      <Tooltip content="Works on any inline content, not just buttons">
+        <span style={{ textDecoration: "underline dotted", cursor: "help" }}>
+          Hover this text
+        </span>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ padding: "3rem" }}>
+      <Tooltip content="You should never see this" disabled>
+        <Button variant="outline">Tooltip disabled</Button>
+      </Tooltip>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- **Card**: new `mediaPosition` prop (`"top" | "left" | "right"`) so the image can sit beside the card body instead of only above it.
- **Tooltip**: brand-new molecule — a floating tooltip triggered by hover, keyboard focus, or touch, with configurable placement, delay, and a fade+scale animation.

## What's new/changed

### `Card` — `mediaPosition` prop (closes #8)
- Files: `src/components/organisms/Card/Card.tsx`, `src/components/organisms/Card/card.css`, `stories/Card.stories.tsx`
- New optional prop `mediaPosition?: "top" | "left" | "right"` (default `"top"`, so existing usage is unchanged).
- `"left"`/`"right"` render the `image` beside the title/subtitle/content/footer using flexbox; collapses back to a stacked top layout at `max-width: 480px`.
- New Storybook stories: **`MediaLeft`**, **`MediaRight`** (under `Components/Organisms/Card`).
- To verify: open those two stories, resize the preview below ~480px and confirm the image moves back above the text.

### `Tooltip` — new component (progress on #5, see note below)
- Files: `src/components/molecules/Tooltip/index.tsx`, `src/components/molecules/Tooltip/tooltip.css`, exported from `src/index.ts`, stories in `stories/Tooltip.stories.tsx`
- Props: `content` (any node), `placement` (`top | bottom | left | right`, default `top`), `delay` (default `300`ms show delay), `hideDelay` (default `0`ms), `disabled`.
- Shows on mouse hover, keyboard focus (Tab), and touch (tap shows immediately, auto-dismisses after ~2.5s or on tapping elsewhere).
- Fade + scale-in entrance using existing motion tokens (`--duration-fast` / `--ease-in-out`); disabled under `prefers-reduced-motion`.
- Implementation note: the trigger is **wrapped**, not cloned — `Button` doesn't forward arbitrary event-handler props, so cloning silently wouldn't have worked when wrapping a `Button`.
- New stories under `Components/Molecules/Tooltip`: `Default`, `Placements` (all 4 sides), `KeyboardAccessible`, `CustomDelay`, `RichContent`, `WrappingNonButtonContent`, `Disabled`.
- To verify: open each story and hover/Tab to the trigger; check the tooltip appears in the right spot, animates in/out, and the `Disabled` story shows nothing on hover.

### Housekeeping
- `CHANGELOG.md` updated under `## WIP` for both changes, per this repo's `AGENTS.md` convention.

## Issue status
- **#8** (Card media slot) — closed, fully implemented here.
- **#5** (tooltip) — left **open**. This PR adds a general-purpose `Tooltip` as a foundation, but does not implement the modifier-key "hold Ctrl to see more" reveal behavior that issue actually asks for — that's a distinct follow-up.
- **#9** and **#10** were closed separately as already-implemented by existing `Button`/`Container` props (no code change needed, not part of this diff).

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm run build-storybook` — passes
- [x] Manual verification via Playwright against the Storybook dev server: confirmed tooltip opacity toggles correctly on hover-in, hover-out, and keyboard focus; screenshotted placement stories to check positioning
- [ ] Human check: visually review Storybook for both `Card` media stories and all `Tooltip` stories (listed above)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAjP5YJiUcWUkTwTfsETSN)_