### PR TITLE
Bump version to 1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This file documents planned and completed changes for the repository.
 
 ## WIP
 
+## Version history
+
+### v1.0.11
 - **Carousel (new organism):** Rotates through slides with a simple crossfade, arrow + dot navigation that loops at either end, and autoplay (configurable interval) that pauses on hover or focus. Drops straight into Card's `image` slot with no special integration needed. Closes [#13].
 - **Card — expand to modal (new):** `longDescription` prop makes a card grow in place into a larger modal-like view with a darkened, non-interactive backdrop and a bouncy overshoot animation; expanded image position is configurable (`"top" | "between"`). `href` takes precedence over click-to-expand, so linked cards require the dedicated expand button.
 - **Tooltip (new molecule):** Floating tooltip that shows on hover, keyboard focus, or touch. `placement` (top/bottom/left/right), `delay`/`hideDelay`, `disabled`, and arbitrary `content`. Fade+scale animation respecting `prefers-reduced-motion`. Basic building block toward #5 — modifier-key reveal behavior from that issue is not yet implemented.
@@ -24,9 +27,6 @@ This file documents planned and completed changes for the repository.
 - **Badge + Box molecules (new):** Badge — compact notification indicator (`count`, `max`, `dot`, wraps element at top-right). Box — low-level layout primitive with padding/margin/rounded/shadow/background/`as` props.
 - **Breadcrumbs organism (new):** Accessible `<nav aria-label="Breadcrumb">` with `items`, `separator`, themed link + muted current-page label. Select gains `maxVisibleItems` (listbox mode).
 - **Portfolio audit:** Projects use `CardGrid`, project cards show `category` Pill (secondary), headings use `gradient`/`animateIn`. Card `--interactive` gains `:active` scale-down press animation.
-
-
-## Version history
 
 ### v1.0.10
 - **CSS export fix:** Package now properly exports all component and theme styles. Added side-effect CSS import in main entry, exposed `dist/index.css` via package.json exports with `style` field, and converted Button CSS modules to global classes (`nw-button`, `nw-button--*`). Consuming apps automatically get styles when importing components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noahwright/design",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noahwright/design",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noahwright/design",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Noah Wright's React design system. Learning in public; use at your own risk.",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
- PR #17 (Card expand-to-modal + Carousel) merged into `main` without a version bump, so the published package still pointed at 1.0.10 with none of that work.
- Bumps `package.json`/`package-lock.json` to `1.0.11`.
- Moves the accumulated `CHANGELOG.md` `## WIP` entries (Carousel, Card modal, Tooltip, and the older backlog items sitting in WIP) into a new `### v1.0.11` entry under `## Version history`, per the CHANGELOG's own release convention, leaving `## WIP` empty for the next round of work.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxxm4ao8ygUQ93VRbQfNHC)_